### PR TITLE
\@ was parsed on ansible 2.0.1 as \\@ and it breaks the src file path

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -28,7 +28,7 @@
 # This separation is necessary because systemd doesn't allow individual unit files to be auto-started
 # systemctl enable openvpn@.service does work, but that results in a service named openvpn@multi-user.service
 - name: setup openvpn auto-start (systemd)
-  file: src=/lib/systemd/system/openvpn\@.service dest=/etc/systemd/system/multi-user.target.wants/{{openvpn_service_name}} state=link owner=root group=root
+  file: src=/lib/systemd/system/openvpn@.service dest=/etc/systemd/system/multi-user.target.wants/{{openvpn_service_name}} state=link owner=root group=root
   when: systemd.rc == 0
 
 # systemctl start openvpn@.service returns


### PR DESCRIPTION
example:     "src": "/lib/systemd/system/openvpn\\@.service".  That path is not exist so we need to remove the backslash to correct that