### PR TITLE
remove sudo: true from firewalld tasks

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,26 +1,20 @@
 - name: Enable OpenVPN Port (firewalld)
   firewalld: port={{openvpn_port}}/{{openvpn_proto}} state=enabled permanent=yes zone=external # immediate=yes only on ansible>=1.9
-  sudo: true
 
 - name: Set tun0 interface to internal
   command: firewall-cmd --zone=internal --change-interface=tun0
-  sudo: true
 
 - name: Persist tun0 settings
   command: firewall-cmd --zone=internal --change-interface=tun0 --permanent
-  sudo: true
 
 - name: Set default interface to external
   command: firewall-cmd --zone={{firewalld_default_interface_zone}} --change-interface={{ansible_default_ipv4.interface}}
-  sudo: true
 
 - name: Persist default interface to external
   command: firewall-cmd --zone={{firewalld_default_interface_zone}} --change-interface={{ansible_default_ipv4.interface}} --permanent
-  sudo: true
 
 - name: Enable masquerading on external zone
   command: firewall-cmd --zone={{firewalld_default_interface_zone}} --add-masquerade
-  sudo: true
 
 # workaround for --permanent not working on non-NetworkManager managed ifaces
 # https://bugzilla.redhat.com/show_bug.cgi?id=1112742
@@ -33,5 +27,4 @@
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ansible_default_ipv4.interface}}
     regexp: "^ZONE="
     line: "ZONE={{firewalld_default_interface_zone}}"
-  sudo: true
   when: ifcfg.stat.exists


### PR DESCRIPTION
- incompatible with connecting as root to a server w/o installed sudo
- other tasks requiring privileges are run w/o sudo true anyhow
  so it's better to handle become/become_user elsewhere