### PR TITLE
Replaced sudo with become to avoid deprecation warning

### DIFF
--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -29,7 +29,7 @@
 
 - name: iptables - save everything (CentOS/RHEL/Fedora)
   shell: iptables-save > /etc/sysconfig/iptables
-  sudo: yes
+  become: yes
   when: ansible_os_family == 'RedHat'
 
 - name: iptables - save everything (Debian/Ubuntu)


### PR DESCRIPTION
Since min_ansible_version is set to 2.0, starting to use
become from Ansible 1.9 should be safe.