### PR TITLE
Provide more control of server configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ openvpn_verify_cn: false
 openvpn_redirect_gateway: true
 openvpn_set_dns: true
 openvpn_enable_management: false
+openvpn_server_network: 10.9.0.0
+openvpn_server_netmask: 255.255.255.0
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,9 @@ openvpn_uninstall: false
 openvpn_use_pregenerated_dh_params: false
 openvpn_use_modern_tls: true
 openvpn_verify_cn: false
+openvpn_redirect_gateway: true
+openvpn_set_dns: true
+openvpn_enable_management: false
+
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -19,7 +19,10 @@ tls-version-min 1.2
 tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384:TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384:TLS-ECDHE-RSA-WITH-AES-256-CBC-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256
 {% endif %}
 
-server 10.9.0.0 255.255.255.0
+server {{openvpn_server_network}} {{openvpn_server_netmask}}
+{% if openvpn_server_ipv6_network is defined %}
+server-ipv6 {{openvpn_server_ipv6_network}}
+{% endif %}
 ifconfig-pool-persist ipp.txt
 
 {% if openvpn_redirect_gateway %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -23,6 +23,9 @@ server {{openvpn_server_network}} {{openvpn_server_netmask}}
 {% if openvpn_server_ipv6_network is defined %}
 server-ipv6 {{openvpn_server_ipv6_network}}
 {% endif %}
+{% if openvpn_topology is defined %}
+topology {{openvpn_topology}}
+{% endif %}
 ifconfig-pool-persist ipp.txt
 
 {% if openvpn_redirect_gateway %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -22,11 +22,15 @@ tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384:TLS-ECDHE-RSA-WITH-AES-256-GC
 server 10.9.0.0 255.255.255.0
 ifconfig-pool-persist ipp.txt
 
+{% if openvpn_redirect_gateway %}
 push "redirect-gateway def1 bypass-dhcp"
+{% endif %}
+{% if openvpn_set_dns %}
 push "dhcp-option DNS 208.67.222.222"
 push "dhcp-option DNS 208.67.220.220"
 push "dhcp-option DNS 8.8.8.8"
 push "dhcp-option DNS 8.8.4.4"
+{%endif %}
 keepalive 5 30
 comp-lzo
 persist-key
@@ -41,4 +45,9 @@ verb 3
 {% if openvpn_verify_cn %}
 verify-x509-name OpenVPN-Client-{{inventory_hostname}} name-prefix
 remote-cert-tls client
+{% endif %}
+
+{% if openvpn_enable_management %}
+management /var/run/openvpn/management unix
+management-client-user root
 {% endif %}


### PR DESCRIPTION
- Parameterize IP address and netmask to be served
- New parameters for whether to push default gateway and whether to push DNS
- Optional new features:
  - enablement of management interface on a UNIX domain socket
  - set up IPv6 inside the tunnel

Defaults for the new parameters are set such that nothing will change unless
you override the default value of the parameter.