### PR TITLE
add options with defaults for duo 2fa integration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,5 +15,10 @@ openvpn_enable_management: false
 openvpn_server_network: 10.9.0.0
 openvpn_server_netmask: 255.255.255.0
 
+#force to use ipv6 on server end
+openvpn_server_ipv6: true
+#use provided client name as CN in client cert
+client_key_short_cn: false
+
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -13,6 +13,14 @@
     chdir="{{openvpn_key_dir}}"
     creates={{item}}.key
   with_items: "{{clients}}"
+  when: not client_key_short_cn
+
+- name: generate client key
+  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout {{item}}.key -out {{item}}.csr -days 3650 -subj /CN={{item}}/
+    chdir="{{openvpn_key_dir}}"
+    creates={{item}}.key
+  with_items: "{{clients}}"
+  when: client_key_short_cn
 
 - name: sign client key
   command: openssl x509 -req -in {{item}}.csr -out {{item}}.crt -CA ca.crt -CAkey ca-key.pem -sha256 -days 3650 -extfile openssl-client.ext

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,7 +1,11 @@
 # {{ ansible_managed }}
 
 port {{openvpn_port}}
+{% if openvpn_server_ipv6 %}
 proto {{openvpn_proto}}6
+{% else %}
+proto {{openvpn_proto}}
+{% endif %}
 dev tun
 
 ca {{openvpn_key_dir}}/ca.crt


### PR DESCRIPTION
problems:
when using openvpn with duo security, I found that duo's plugin
does not make calls to duo's server at all when server proto is
'udp6', the problem goes away when proto is 'udp'.
duo also uses client CN in user certificate as username for
authentication. when both openvpn and ssh are integrated with
duo on one host, the CN has to match linux OS user name.

solution:
add these options, the default represents the current behavior.

openvpn_server_ipv6:  when false, allow ipv4 for protocol
default: true

client_key_short_cn: allow CN in client certificate to be
exactly the same as the client name
default: false