### PR TITLE
Enable IPv6 forwarding when IPv6 is in use

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,13 @@
     value=1
     ignoreerrors=yes
 
+- name: enable ipv6 forwarding
+  sysctl: >
+    name=net.ipv6.conf.all.forwarding
+    value=1
+    ignoreerrors=yes
+  when: openvpn_server_ipv6_network is defined
+
 - name: Check for firewalld/iptables
   command: firewall-cmd --state
   register: firewalld


### PR DESCRIPTION
I missed adding this in #7; this is necessary for the IPv6 VPN server to actually pass traffic.