### PR TITLE
Add openvpn_push option to push generic config to the client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ openvpn_redirect_gateway: Whether to push config to the client to redirect its d
 
 openvpn_set_dns: Whether to set the DNS servers on the client. Default true.
 
+openvpn_push: A list of config options for the server to push to the client.
+
 openvpn_enable_management: Boolean indicating whether to open a UNIX domain socket for managing openvpn on /var/run/openvpn/management.
 
 openvpn_server_network: The network address from which you want OpenVPN to choose the addresses for clients. Default 10.9.0.0.

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -37,6 +37,11 @@ push "dhcp-option DNS 208.67.220.220"
 push "dhcp-option DNS 8.8.8.8"
 push "dhcp-option DNS 8.8.4.4"
 {%endif %}
+{% if openvpn_push is defined %}
+{% for opt in openvpn_push %}
+push {{ opt }}
+{% endfor %}
+{% endif %}
 keepalive 5 30
 comp-lzo
 persist-key


### PR DESCRIPTION
Allows configuring an arbitrary list of configuration items to the client. I used it to push a static route, but you can use it to do anything openvpn supports.
