### PR TITLE
minor fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ openvpn_enable_management: false
 openvpn_server_network: 10.9.0.0
 openvpn_server_netmask: 255.255.255.0
 tls_auth_required: true
+ci_build: false
+clients: []
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,7 +11,7 @@
 
 - name: Set openvpn service name - Docker + systemd
   set_fact: openvpn_service_name=openvpn@{{openvpn_config_file}}.service
-  when: stat_result and stat_result.stat.exists == True
+  when: stat_result is defined and stat_result.stat.exists == True
 
 - name: create openvpn config file
   template:

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,10 +1,10 @@
 - name: Enable OpenVPN Port (firewalld)
-  firewalld: >
-    port={{openvpn_port}}/{{openvpn_proto}}
-    state=enabled
-    permanent=yes
-    zone={{firewalld_default_interface_zone}}
-    immediate=yes
+  firewalld:
+    port: "{{openvpn_port}}/{{openvpn_proto}}"
+    state: "enabled"
+    permanent: yes
+    zone: "{{firewalld_default_interface_zone}}"
+    immediate: yes
 
 - name: Set tun0 interface to internal
   command: firewall-cmd --zone=internal --change-interface=tun0


### PR DESCRIPTION
- ci_build was not declared by default and so failled to find the var on ansible 2.2.0
- add a default empty client list.
- fix test for docker service
- review syntax for firewalld config