### PR TITLE
Remove typo 6 from server.conf proto config

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 port {{openvpn_port}}
-proto {{openvpn_proto}}6
+proto {{openvpn_proto}}
 dev tun
 
 ca {{openvpn_key_dir}}/ca.crt


### PR DESCRIPTION
With extra 6 openvpn wont start if TCP proto is used