### PR TITLE
Add CRL and adjust client config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Role Variables
 | openvpn_use_ldap                   | boolean | true , false | false                                          | Active LDAP backend for authentication. Client certificate not needed   anymore                                                                                   |
 | ldap                               | dict    |              |                                                | Dictionary that contain LDAP configuration                                                                                                                        |
 | manage_firewall_rules              | boolean | true , false | true                                           | Allow playbook to manage iptables                                                                                                                                 |
+| crl_path                           | string  |              |                                                | Define a path to the CRL file for revokations.                                                                                                       |
+| openvpn_client_register_dns        | boolean | true , false | true                                           | Add `register-dns` option to client config (Windows only).                                                                                                      |
 
 LDAP object
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Role Variables
 | openvpn_use_ldap                   | boolean | true , false | false                                          | Active LDAP backend for authentication. Client certificate not needed   anymore                                                                                   |
 | ldap                               | dict    |              |                                                | Dictionary that contain LDAP configuration                                                                                                                        |
 | manage_firewall_rules              | boolean | true , false | true                                           | Allow playbook to manage iptables                                                                                                                                 |
-| crl_path                           | string  |              |                                                | Define a path to the CRL file for revokations.                                                                                                       |
+| openvpn_crl_path                   | string  |              |                                                | Define a path to the CRL file for revokations.                                                                                                       |
 | openvpn_client_register_dns        | boolean | true , false | true                                           | Add `register-dns` option to client config (Windows only).                                                                                                      |
 
 LDAP object

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ ci_build: false
 clients: []
 openvpn_push: []
 manage_firewall_rules: true
+openvpn_client_register_dns: true
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -22,7 +22,9 @@ verb 3
 
 route-method exe
 route-delay 2
+{% if openvpn_client_register_dns %}
 register-dns
+{% endfi %}
 
 key-direction 1
 <ca>

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -24,7 +24,7 @@ route-method exe
 route-delay 2
 {% if openvpn_client_register_dns %}
 register-dns
-{% endfi %}
+{% endif %}
 
 key-direction 1
 <ca>

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -12,6 +12,9 @@ ca {{openvpn_key_dir}}/ca.crt
 cert {{openvpn_key_dir}}/server.crt
 key {{openvpn_key_dir}}/server.key
 dh {{openvpn_key_dir}}/dh.pem
+{% if crl_path is defined %}
+crl-verify {{crl_path}}
+{% endif %}
 {% if tls_auth_required %}
 tls-auth {{openvpn_key_dir}}/ta.key 0
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -12,7 +12,7 @@ ca {{openvpn_key_dir}}/ca.crt
 cert {{openvpn_key_dir}}/server.crt
 key {{openvpn_key_dir}}/server.key
 dh {{openvpn_key_dir}}/dh.pem
-{% if crl_path is defined %}
+{% if openvpn_crl_path is defined %}
 crl-verify {{crl_path}}
 {% endif %}
 {% if tls_auth_required %}


### PR DESCRIPTION
- If you need to revoke certificates, you need to define a `crl-verify`
  option for the server. This adds that option, although managing this
  file is outside the scope of this commit.
- `register-dns` for the client config is apparently a Windows-only
  option. Make this optional.