### PR TITLE
Allow server hostname to be set for client configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Role Variables
 |------------------------------------|---------|--------------|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | openvpn_key_dir                    | string  |              | /etc/openvpn/keys                              | Path where your server private keys and CA will be stored                                                                                                         |
 | openvpn_port                       | int     |              | 1194                                           | The port you want OpenVPN to run on. If you have different ports on   different servers, I suggest you set the port in your inventory file.                       |
+| openvpn_server_hostname            | string  |              | `{{inventory_hostname}}`                       | The server name to place in the client configuration file (if different from the `inventory_hostname`             |
 | openvpn_proto | string  | udp, tcp | udp | The protocol you want OpenVPN to use |
 | openvpn_dualstack | boolean | | true | Whether or not to use a dualstack (IPv4 + v6) socket |
 | openvpn_config_file                | string  |              | openvpn_{{ openvpn\_proto }}_{{ openvpn_port }} |  The config file name you want to   use                                                                                                                          |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for openvpn
 openvpn_key_dir: /etc/openvpn/keys
 openvpn_port: 1194
+openvpn_server_hostname: "{{inventory_hostname}}"
 openvpn_proto: udp
 openvpn_dualstack: true
 openvpn_rsa_bits: 2048

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -9,7 +9,7 @@ tls-version-min 1.2
 {% endif %}
 
 proto {{openvpn_proto}}
-remote {{inventory_hostname}} {{openvpn_port}}
+remote {{openvpn_server_hostname}} {{openvpn_port}}
 dev tun
 
 resolv-retry 5


### PR DESCRIPTION
Sometimes the `inventory_hostname` is not the DNS hostname that clients should use to connect this. This allows one to override.