### PR TITLE
Fix to openvpn_service_name setting when clause

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,7 +7,7 @@
 - name: set openvpn service name - systemd
   set_fact:
     openvpn_service_name: "openvpn@{{openvpn_config_file}}.service"
-  when: ansible_service_mgr == "systemd" or (docker_stat_result is defined and docker_stat_result.stat.exists == True)
+  when: ansible_service_mgr == "systemd" or (docker_stat_result.stat is defined and docker_stat_result.stat.exists == True)
 
 - name: create openvpn config file
   template:


### PR DESCRIPTION
playbook fails in "set openvpn service name - systemd" task in Amazon Linux (RedHat) on Ansible 2.3.0 because docker_stat_result.stat.exists is not defined.

A skipped task still defines its registered variable, so docker_stat_result will always be defined.  We need to check if docker_stat_result.stat is defined before using it.