### PR TITLE
ensure certificate revocation list database exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ after_script:
   - sudo docker exec ${OS_TAG} cat /var/log/openvpn.log
   - sudo docker stop ${OS_TAG}
 
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+# notifications:
+#   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ after_script:
   - sudo docker exec ${OS_TAG} cat /var/log/openvpn.log
   - sudo docker stop ${OS_TAG}
 
-# notifications:
-#   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -41,8 +41,11 @@
     masquerade: true
     zone: "{{firewalld_default_interface_zone}}"
     permanent: true
-    immediate: true
     state: enabled
+    #Workarround ansible issue: https://github.com/ansible/ansible/pull/21693
+    #immediate: true
+  notify:
+    - restart firewalld
 
 # workaround for --permanent not working on non-NetworkManager managed ifaces
 # https://bugzilla.redhat.com/show_bug.cgi?id=1112742

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -127,9 +127,13 @@
     group: root
     mode: 744
 
+- name: ensure certificate revocation list database exists
+  file:
+    path: "{{openvpn_key_dir}}/index.txt"
+    state: touch
+
 - name: set up certificate revocation list
   command: sh revoke.sh
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ openvpn_key_dir }}/ca-crl.pem"
-


### PR DESCRIPTION
When setting up a server from scratch with openvpn, the certificate revocation list needs a "database" file to exist in order to generate the ca-crl.pem file. If the file does not exist, the revoke.sh script fails to generate the key file, but does not exit with an error and ansible continues on to the next task. When the service tries to start, it fails, with the following logged in the openvpn.log file:
```
Options error: --crl-verify fails with '/etc/openvpn/keys/ca-crl.pem': No such file or directory
```
This merge will create the database file before attempting to generate the CRL key file.