### PR TITLE
Limit client key CN to 64 characters

### DIFF
--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -9,7 +9,7 @@
     mode: 0400
 
 - name: generate client key
-  command: "openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout {{item}}.key -out {{item}}.csr -days 3650 -subj /CN=OpenVPN-Client-{{inventory_hostname}}-{{item}}/"
+  command: "openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout {{item}}.key -out {{item}}.csr -days 3650 -subj /CN=OpenVPN-Client-{{ inventory_hostname[:24] }}-{{ item[:24] }}/"
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{item}}.key"

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -29,7 +29,7 @@
   when: openvpn_ca_key is defined
 
 - name: Generate CA key
-  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout ca-key.pem -out ca-csr.pem -days 3650 -subj /CN=OpenVPN-CA-{{inventory_hostname}}/
+  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout ca-key.pem -out ca-csr.pem -days 3650 -subj /CN=OpenVPN-CA-{{inventory_hostname[:53]}}/
   args:
     chdir: "{{openvpn_key_dir}}"
     creates: ca-key.pem
@@ -49,7 +49,7 @@
   when: openvpn_ca_key is not defined
 
 - name: generate server key
-  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout server.key -out server.csr -days 3650 -subj /CN=OpenVPN-Server-{{inventory_hostname}}/
+  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout server.key -out server.csr -days 3650 -subj /CN=OpenVPN-Server-{{inventory_hostname[:49]}}/
   args:
     chdir: "{{openvpn_key_dir}}"
     creates: server.key

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -44,5 +44,5 @@ key-direction 1
 </key>
 
 {% if openvpn_verify_cn|bool %}
-verify-x509-name OpenVPN-Server-{{inventory_hostname}} name
+verify-x509-name OpenVPN-Server-{{inventory_hostname[:49]}} name
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -65,7 +65,7 @@ log-append /var/log/openvpn.log
 verb 3
 
 {% if openvpn_verify_cn|bool %}
-verify-x509-name OpenVPN-Client-{{inventory_hostname}} name-prefix
+verify-x509-name OpenVPN-Client-{{inventory_hostname[:24]}} name-prefix
 remote-cert-tls client
 {% endif %}
 


### PR DESCRIPTION
X.509 CN has a max length of 64: https://tools.ietf.org/html/rfc5280#appendix-A.1

This fails my run on:
`problems making Certificate Request ... asn1 encoding routines:ASN1_mbstring_ncopy:string too long:a_mbstr.c:158:maxsize=64`