### PR TITLE
Actually add F27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ env:
     - DOCKER_TAG=fedora:25
       OS_TAG=fedora-25
       OS=fedora
-    - DOCKER_TAG=fedora:24
-      OS_TAG=fedora-24
-      OS=fedora
     - DOCKER_TAG=ubuntu:16.10
       DOCKER_ARGS=-t
       OS_TAG=ubuntu-16.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ env:
     - DOCKER_TAG=fedora:latest
       OS_TAG=fedora-latest
       OS=fedora
+    - DOCKER_TAG=fedora:27
+      OS_TAG=fedora-27
+      OS=fedora
+    - DOCKER_TAG=fedora:26
+      OS_TAG=fedora-26
+      OS=fedora
     - DOCKER_TAG=fedora:25
       OS_TAG=fedora-25
       OS=fedora

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ openvpn
 This role installs OpenVPN, configures it as a server, sets up networking (either iptables or firewalld), and can optionally create client certificates.
 
 Tested OSes:
-- Fedora 20/21
-- CentOS 6/7
-- Ubuntu trusty (14.04)
+- Fedora 25+
+- CentOS 7
+- Ubuntu 16.04/16.10
 
 Should be working OSes:
 - All Fedora
+- All RHEL/CentOS
 - Ubuntu trusty & later
 
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: OpenVPN playbook for CentOS/Fedora/RHEL/RHEL clones & Ubuntu/Debian
 
   license: GPLv2
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,15 +1,4 @@
-- name: Check systemd existence as Docker Guest
-  stat:
-    path: /bin/systemctl
-  when: ansible_virtualization_role is defined and ansible_virtualization_type == "docker" and ansible_virtualization_role == "guest"
-  register: docker_stat_result
-
-- name: set openvpn service name - systemd
-  set_fact:
-    openvpn_service_name: "openvpn@{{openvpn_config_file}}.service"
-  when: ansible_service_mgr == "systemd" or (docker_stat_result.stat is defined and docker_stat_result.stat.exists == True)
-
-- name: create openvpn config file
+- name: Create openvpn config file
   template:
     src: server.conf.j2
     dest: "{{ openvpn_base_dir }}/{{openvpn_config_file}}.conf"
@@ -26,7 +15,7 @@
     group: root
   when: openvpn_use_ldap
 
-- name: copy openvpn logrotate config file
+- name: Copy openvpn logrotate config file
   copy:
     src: openvpn_logrotate.conf
     dest: /etc/logrotate.d/openvpn.conf
@@ -35,7 +24,7 @@
     mode: 0400
   when: ansible_os_family != 'Solaris'
 
-- name: setup openvpn auto-start & start
+- name: Setup openvpn auto-start & start
   service:
     name: "{{openvpn_service_name}}"
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,23 +2,29 @@
 # tasks file for openvpn
 - include_vars: "{{ item }}"
   with_first_found:
+    - "../vars/{{ ansible_distribution }}{{ ansible_distribution_major_version }}.yml"
+    - "../vars/{{ ansible_distribution }}.yml"
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/empty.yml"
   tags: [always]
 
+- name: Set facts
+  include_tasks: set_facts.yml
+  tags: [always]
+
 - name: Uninstall OpenVPN
-  include: uninstall.yml
+  include_tasks: uninstall.yml
   when: openvpn_uninstall
   tags:
     - uninstall
 
 - name: Install OpenVPN
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - install
 
 - name: Copy or Generate server keys
-  include: server_keys.yml
+  include_tasks: server_keys.yml
   tags:
     - server_keys
 
@@ -39,27 +45,27 @@
     ignoreerrors: yes
   when: openvpn_server_ipv6_network is defined and not ci_build
 
-- name: Detect firewall
-  include: firewall.yml
+- name: Detect firewall type
+  include_tasks: firewall.yml
   when:
     - not ci_build
     - manage_firewall_rules
   tags:
     - firewall
 
-- name: generate client configs
-  include: client_keys.yml
+- name: Generate client configs
+  include_tasks: client_keys.yml
   when: clients is defined
   tags:
     - client_keys
 
-- name: generate revocation list and clean up
-  include: revocation.yml
+- name: Generate revocation list and clean up
+  include_tasks: revocation.yml
   when: openvpn_revoke_these_certs is defined
   tags:
     - revocation
 
-- name: configure OpenVPN
-  include: config.yml
+- name: Configure OpenVPN server
+  include_tasks: config.yml
   tags:
     - configure

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -1,4 +1,4 @@
-- name: create openvpn key directory
+- name: Create openvpn key directory
   file:
     path: "{{openvpn_key_dir}}"
     state: directory
@@ -35,7 +35,7 @@
     creates: ca-key.pem
   when: openvpn_ca_key is not defined
 
-- name: protect CA key
+- name: Protect CA key
   file:
     path: "{{openvpn_key_dir}}/ca-key.pem"
     mode: 0400

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,15 +1,4 @@
-- name: Check systemd existence as Docker Guest
-  stat:
-    path: /bin/systemctl
-  when: ansible_virtualization_type == "docker" and ansible_virtualization_role == "guest"
-  register: docker_stat_result
-
-- name: set openvpn service name - systemd
-  set_fact:
-    openvpn_service_name: "openvpn@{{openvpn_config_file}}.service"
-  when: ansible_service_mgr == "systemd" or (docker_stat_result is defined and docker_stat_result.stat.exists == True)
-
-- name: disable openvpn auto-start & start
+- name: Disable openvpn auto-start & start
   service:
     name: "{{openvpn_service_name}}"
     enabled: no


### PR DESCRIPTION
Fedora changed the layout on disk, which is why stuff broke (mainly added new subfolders `client` and `server` in `/etc/openvpn`, referenced them in the unit file which automatically got pulled in.

Added support for version specific vars, but would need to add it to every future version, which doesn't work well.