### PR TITLE
Check openvpn_use_crl as bool

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -15,7 +15,7 @@ dh {{openvpn_key_dir}}/dh.pem
 {% if openvpn_crl_path is defined %}
 crl-verify {{openvpn_crl_path}}
 {% endif %}
-{% if openvpn_use_crl is defined %}
+{% if openvpn_use_crl|bool %}
 crl-verify {{openvpn_key_dir}}/ca-crl.pem
 {% endif %}
 {% if tls_auth_required %}


### PR DESCRIPTION
It's always defined, as it is in `defaults.yml`. This should also fix https://github.com/kyl191/ansible-role-openvpn/issues/54