### PR TITLE
Add SmartOS support to crl updates

### DIFF
--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -149,6 +149,8 @@
 - name: Add cron to check every Saturday if the CRL needs to be renewed
   cron:
     name: "check if CRL will expire soon"
-    special_time: weekly
+    weekday: 6
+    minute: 10
+    hour: 0
     job: "sh {{ openvpn_base_dir }}/crl-cron.sh"
   when: not ci_build

--- a/templates/crl-cron.sh.j2
+++ b/templates/crl-cron.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-lastUpdate=$(date --date "$(openssl crl -in ca-crl.pem -noout -lastupdate | cut -d'=' -f2)" +%s)
-nextUpdate=$(date --date "$(openssl crl -in ca-crl.pem -noout -nextupdate | cut -d'=' -f2)" +%s)
+lastUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -noout -lastupdate | cut -d'=' -f2)" +%s)
+nextUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -noout -nextupdate | cut -d'=' -f2)" +%s)
 
 if [ $(( (nextUpdate - lastUpdate) / 86400 )) -le 10 ]; then
     sh {{ openvpn_key_dir }}/revoke.sh


### PR DESCRIPTION
- special_time cron setting does not work in Solaris
- openssl is accessing the wrong file