### PR TITLE
Add support for Mikrotik as openvpn client

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Role Variables
 | openvpn_resolv_retry               | int/string | any int, infinite | 5                                      | Hostname resolv failure retry seconds. Set "infinite" to retry indefinitely in case of poor connection or laptop sleep mode recovery etc.                         |
 | openvpn_client_to_client           | boolean | true, false  | false                                          | Set to true if you want clients to access each other.                                                                                                             |
 | openvpn_masquerade_not_snat        | boolean | true, false  | false                                          | Set to true if you want to set up MASQUERADE instead of the default SNAT in iptables.                                                 |
+| openvpn_compression                | string  |              | lzo                                            | Set `compress` compression option. Empty for no compression.                                                                                                      |
+| openvpn_auth_alg                   | string  |              | SHA256                                         | Set `auth` authentication algoritm.                                                                                                                               |
+| openvpn_tun_mtu                    | int     |              |                                                | Set `tun-mtu` value. Empty for default.                                                                                                                           |
+
 
 LDAP object
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ openvpn_client_to_client: false
 openvpn_masquerade_not_snat: false
 openvpn_addl_server_options: []
 openvpn_addl_client_options: []
-openvpn_compression: yes
+openvpn_compression: lzo
 openvpn_auth_alg: SHA256
 openvpn_tun_mtu:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ openvpn_client_to_client: false
 openvpn_masquerade_not_snat: false
 openvpn_addl_server_options: []
 openvpn_addl_client_options: []
+openvpn_compression: yes
+openvpn_auth_alg: SHA256
+openvpn_tun_mtu:
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -71,8 +71,8 @@ push "{{ opt }}"
 {% endfor %}
 {% endif %}
 keepalive 5 30
-{% if openvpn_compression %}
-compress lzo
+{% if openvpn_compression is not none %}
+compress {{ openvpn_compression }}
 {% endif %}
 persist-key
 persist-tun

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -22,8 +22,11 @@ crl-verify {{openvpn_key_dir}}/ca-crl.pem
 tls-auth {{openvpn_key_dir}}/ta.key 0
 {% endif %}
 tls-server
-auth SHA256
+auth {{ openvpn_auth_alg | default('SHA256') }}
 cipher AES-256-CBC
+{% if openvpn_tun_mtu is not none %}
+tun-mtu {{ openvpn_tun_mtu }}
+{% endif %}
 {% if openvpn_use_hardened_tls|bool %}
 tls-version-min 1.2
 {% endif %}
@@ -68,7 +71,9 @@ push "{{ opt }}"
 {% endfor %}
 {% endif %}
 keepalive 5 30
+{% if openvpn_compression %}
 compress lzo
+{% endif %}
 persist-key
 persist-tun
 user nobody


### PR DESCRIPTION
Add support for `Mikrotik` as openvpn client, Also fix #73 

Mikrotik does not support `compression`, auth `SHA256` (require auth `sha1`) and want `mtu` set.
Make this options configurable
