### PR TITLE
Debian fact check fix

### DIFF
--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -2,7 +2,7 @@
   set_fact:
     iptables_save_command: "/usr/sbin/netfilter-persistent save"
     iptables_service: netfilter-persistent
-  when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
+  when: (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
 
 - name: Install iptables-persistent (Debian/Ubuntu)
   package:


### PR DESCRIPTION
I can confirm that your ansible role works like a charm on Debian 9 / Stretch (thanks for that btw :) ).  
The only thing not working is the facts lookup for major_release, as this doesn't seem to exist for Debian.  

