### PR TITLE
Fix ufw task according to Ansible 2.7.8 changes

### DIFF
--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -6,6 +6,7 @@
 
 - name: Enable ufw
   ufw:
+    direction: incoming
     state: enabled
     policy: allow
 


### PR DESCRIPTION
Since Ansible 2.7.8 `direction` param is required: https://github.com/ansible/ansible/pull/50402/files#diff-476edcbbb72b9029f5b116b4c813c076R403