### PR TITLE
Fix firewall checks for ubuntu-xenial-16.04 AMI

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,19 +1,19 @@
 - name: Check for firewalld
-  command: command -v firewall-cmd
+  shell: command -v firewall-cmd
   register: firewalld
   check_mode: no
   changed_when: false  # Never report as changed
   failed_when: false
 
 - name: Check for ufw
-  command: command -v ufw
+  shell: command -v ufw
   register: ufw
   check_mode: no
   changed_when: false  # Never report as changed
   failed_when: false
 
 - name: Check for iptables
-  command: command -v iptables
+  shell: command -v iptables
   register: iptables
   check_mode: no
   changed_when: false  # Never report as changed


### PR DESCRIPTION
Firewall checks don't work properly on AWS AMI `ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20190628 (ami-0b37e9efc396e4c38)`