### PR TITLE
Enable configuration of keepalive values

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Role Variables
 | openvpn_log_dir                    | string  |              | /var/log                                       | Set location of openvpn log files. This parameter is a part of `log-append` configuration value.                                                                  |
 | openvpn_log_file                   | string  |              | openvpn.log                                    | Set log filename. This parameter is a part of `log-append` configuration value.                                                                                   |
 | openvpn_logrotate_config           | string  |              | See defaults/main.yml                          | Configure logrotate script.                                                                                                                                       |
+| openvpn_keepalive_ping             | int     |              | 5                                              | Set `keepalive` ping interval seconds.                                                                                                                            |
+| openvpn_keepalive_timeout          | int     |              | 30                                             | Set `keepalive` timeout seconds                                                                                                                                   |
 
 
 LDAP object

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,8 @@ openvpn_addl_client_options: []
 openvpn_compression: lzo
 openvpn_auth_alg: SHA256
 openvpn_tun_mtu:
+openvpn_keepalive_ping: 5
+openvpn_keepalive_timeout: 30
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -14,7 +14,7 @@ dev tun
 
 resolv-retry {{ openvpn_resolv_retry }}
 nobind
-keepalive 5 30
+keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
 {% if openvpn_compression is not none %}
 compress {{ openvpn_compression }}
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -70,7 +70,7 @@ push "dhcp-option DNS 8.8.4.4"
 push "{{ opt }}"
 {% endfor %}
 {% endif %}
-keepalive 5 30
+keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
 {% if openvpn_compression %}
 compress {{ openvpn_compression }}
 {% endif %}


### PR DESCRIPTION
Add two variables for separately configuring `keepalive` ping and timeout.