### PR TITLE
Enable configuration of process user and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Role Variables
 | openvpn_log_dir                    | string  |              | /var/log                                       | Set location of openvpn log files. This parameter is a part of `log-append` configuration value.                                                                  |
 | openvpn_log_file                   | string  |              | openvpn.log                                    | Set log filename. This parameter is a part of `log-append` configuration value.                                                                                   |
 | openvpn_logrotate_config           | string  |              | See defaults/main.yml                          | Configure logrotate script.                                                                                                                                       |
+| openvpn_service_user               | string  |              | nobody                                         | Set the openvpn service user.                                                                                                                                     |
+| openvpn_service_group              | string  |              | nogroup                                        | Set the openvpn service group.                                                                                                                                    |
 
 
 LDAP object

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,8 @@ openvpn_addl_client_options: []
 openvpn_compression: lzo
 openvpn_auth_alg: SHA256
 openvpn_tun_mtu:
+openvpn_service_user: nobody
+openvpn_service_group: nogroup
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -76,8 +76,8 @@ compress {{ openvpn_compression }}
 {% endif %}
 persist-key
 persist-tun
-user nobody
-group nogroup
+user {{ openvpn_service_user }}
+group {{ openvpn_service_group }}
 
 {% for option in openvpn_addl_server_options %}
 {{ option }}


### PR DESCRIPTION
Provides the ability of running the openvpn process under an atypical user and/or group.