### PR TITLE
use full path for ca-crl.pem

### DIFF
--- a/templates/crl-cron.sh.j2
+++ b/templates/crl-cron.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-lastUpdate=$(date --date "$(openssl crl -in ca-crl.pem -noout -lastupdate | cut -d'=' -f2)" +%s)
-nextUpdate=$(date --date "$(openssl crl -in ca-crl.pem -noout -nextupdate | cut -d'=' -f2)" +%s)
+lastUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -noout -lastupdate | cut -d'=' -f2)" +%s)
+nextUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -noout -nextupdate | cut -d'=' -f2)" +%s)
 
 if [ $(( (nextUpdate - lastUpdate) / 86400 )) -le 10 ]; then
     sh {{ openvpn_key_dir }}/revoke.sh


### PR DESCRIPTION
As pointed out in #87, the cron-script needs to use the full path, otherwise it will throw the following errors:

```bash
user@server:/etc/openvpn$  ./crl-cron.sh
crl: Cannot open input file ca-crl.pem, No such file or directory
crl: Use -help for summary.
crl: Cannot open input file ca-crl.pem, No such file or directory
crl: Use -help for summary.
Using configuration from ca.conf
Can't open /etc/openvpn/keys/index.txt.attr for reading, No such file or directory
139849817899072:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:74:fopen('/etc/openvpn/keys/index.txt.attr','r')
139849817899072:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:81:
```


closes #87