### PR TITLE
hotfix: Bad LZO decompression

### DIFF
--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -21,7 +21,7 @@
 - name: iptables - Allow VPN forwarding
   iptables:
     chain: FORWARD
-    source: "{{openvpn_server_network}}/24"
+    source: "{{openvpn_server_network}}/22"
     jump: ACCEPT
     action: insert
     comment: "Allow VPN forwarding"
@@ -60,7 +60,7 @@
   iptables:
     table: nat
     chain: POSTROUTING
-    source: "{{openvpn_server_network}}/24"
+    source: "{{openvpn_server_network}}/22"
     to_source: "{{ansible_default_ipv4.address}}"
     jump: SNAT
     action: insert
@@ -72,7 +72,7 @@
   iptables:
     table: nat
     chain: POSTROUTING
-    source: "{{openvpn_server_network}}/24"
+    source: "{{openvpn_server_network}}/22"
     jump: MASQUERADE
     action: insert
     comment: "Perform NAT readdressing"

--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -38,7 +38,7 @@
       # OpenVPN config
       *nat
       :POSTROUTING ACCEPT [0:0]
-      -A POSTROUTING -s {{openvpn_server_network}}/24 -j SNAT --to-source {{ansible_default_ipv4.address}}
+      -A POSTROUTING -s {{openvpn_server_network}}/22 -j SNAT --to-source {{ansible_default_ipv4.address}}
       COMMIT
   when: not openvpn_masquerade_not_snat
   notify:
@@ -53,7 +53,7 @@
       # OpenVPN config
       *nat
       :POSTROUTING ACCEPT [0:0]
-      -A POSTROUTING -s {{openvpn_server_network}}/24 -j MASQUERADE
+      -A POSTROUTING -s {{openvpn_server_network}}/22 -j MASQUERADE
       COMMIT
   when: openvpn_masquerade_not_snat
   notify:

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -16,7 +16,7 @@ resolv-retry {{ openvpn_resolv_retry }}
 nobind
 keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
 {% if openvpn_compression is not none %}
-compress {{ openvpn_compression }}
+comp-{{ openvpn_compression }}
 {% endif %}
 persist-key
 persist-tun

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -75,7 +75,7 @@ push "{{ opt }}"
 {% endif %}
 keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
 {% if openvpn_compression %}
-compress {{ openvpn_compression }}
+comp-{{ openvpn_compression }}
 {% endif %}
 persist-key
 persist-tun


### PR DESCRIPTION
**OS:** 
CentOS Linux 8 | 8.2.2004
**OpenVpn:** 
OpenVPN 2.4.9 x86_64-redhat-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] built on Apr 24 2020
library versions: OpenSSL 1.1.1c FIPS  28 May 2019, LZO 2.08

**Error Description**
got this error "Bad LZO decompression header byte: 69"

**Status**
fixed

log
```
***:26679 TLS: Initial packet from [AF_INET6]::ffff:***:26679, sid=c9d6bf41 03d3a7df
***:26679 VERIFY OK: depth=1, CN=OpenVPN-CA-18.197.108.79
***:26679 VERIFY OK: depth=0, CN=OpenVPN-Client-18.197.108.79-client3
***:26679 peer info: IV_VER=2.4.7
***:26679 peer info: IV_PLAT=linux
***:26679 peer info: IV_PROTO=2
***:26679 peer info: IV_NCP=2
***26679 peer info: IV_LZ4=1
***:26679 peer info: IV_LZ4v2=1
***:26679 peer info: IV_LZO=1
***:26679 peer info: IV_COMP_STUB=1
***:26679 peer info: IV_COMP_STUBv2=1
***:26679 peer info: IV_TCPNL=1
***:26679 WARNING: 'link-mtu' is used inconsistently, local='link-mtu 1570', remote='link-mtu 1569'
***:26679 WARNING: 'comp-lzo' is present in local config but missing in remote config, local='comp-lzo'
***:26679 Control Channel: TLSv1.3, cipher TLSv1.3 TLS_AES_256_GCM_SHA384, 2048 bit RSA
***:26679 [OpenVPN-Client-18.197.108.79-client3] Peer Connection Initiated with [AF_INET6]::ffff:***:26679
OpenVPN-Client-18.197.108.79-client3/***:26679 MULTI_sva: pool returned IPv4=10.9.0.6, IPv6=(Not enabled)
OpenVPN-Client-18.197.108.79-client3/***:26679 MULTI: Learn: 10.9.0.6 -> OpenVPN-Client-18.197.108.79-client3/***:26679
OpenVPN-Client-18.197.108.79-client3/***:26679 MULTI: primary virtual IP for OpenVPN-Client-18.197.108.79-client3/***:26679: 10.9.0.6
OpenVPN-Client-18.197.108.79-client3/***:26679 PUSH: Received control message: 'PUSH_REQUEST'
OpenVPN-Client-18.197.108.79-client3/***:26679 SENT CONTROL [OpenVPN-Client-18.197.108.79-client3]: 'PUSH_REPLY,redirect-gateway def1 bypass-dhcp,dhcp-option DNS 1.0.0.1,dhcp-option DNS 1.1.1.1,dhcp-option DNS 8.8.8.8,dhcp-option DNS 8.8.4.4,route 10.9.0.1,topology net30,ping 5,ping-restart 30,ifconfig 10.9.0.6 10.9.0.5,peer-id 0,cipher AES-256-GCM' (status=1)
OpenVPN-Client-18.197.108.79-client3/***:26679 Data Channel: using negotiated cipher 'AES-256-GCM'
OpenVPN-Client-18.197.108.79-client3/***:26679 Outgoing Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
OpenVPN-Client-18.197.108.79-client3***:26679 Incoming Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
OpenVPN-Client-18.197.108.79-client3/***:26679 Bad LZO decompression header byte: 96
OpenVPN-Client-18.197.108.79-client3/***:26679 Bad LZO decompression header byte: 69
OpenVPN-Client-18.197.108.79-client3/***:26679 Bad LZO decompression header byte: 69

```