### PR TITLE
Make ifconfig-pool-persist configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ openvpn_keepalive_timeout: 30
 openvpn_service_user: nobody
 openvpn_service_group: nogroup
 openvpn_selinux_module: my-openvpn-server
+openvpn_ifconfig_pool_persist_file: ipp.txt
 
 # Used in firewalld
 firewalld_default_interface_zone: public

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -51,7 +51,7 @@ server-ipv6 {{openvpn_server_ipv6_network}}
 {% if openvpn_topology is defined %}
 topology {{openvpn_topology}}
 {% endif %}
-ifconfig-pool-persist ipp.txt
+ifconfig-pool-persist {{ openvpn_ifconfig_pool_persist_file }}
 
 {% if openvpn_redirect_gateway|bool %}
 push "redirect-gateway def1 bypass-dhcp"


### PR DESCRIPTION
This is needed for [multi instance](https://github.com/kyl191/ansible-role-openvpn/issues/34) setups with multiple IP pools.