### PR TITLE
Set auth-user-pass in client config if ldap auth is used

### DIFF
--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -22,6 +22,10 @@ persist-key
 persist-tun
 verb 3
 
+{% if openvpn_use_ldap %}
+auth-user-pass
+{% endif %}
+
 {% for option in openvpn_addl_client_options %}
 {{ option }}
 {% endfor %}


### PR DESCRIPTION
This seems to be needed in a client cert + LDAP auth setup otherwise the client does not ask for the LDAP credentials and therefore always fails to connect.