### PR TITLE
synchronized the compression settings for client and server

### DIFF
--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -15,7 +15,7 @@ dev tun
 resolv-retry {{ openvpn_resolv_retry }}
 nobind
 keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
-{% if openvpn_compression is undefined or openvpn_compression == "" %}
+{% if openvpn_compression is not undefined and openvpn_compression != "" %}
 compress {{ openvpn_compression }}
 {% endif %}
 persist-key

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -15,7 +15,7 @@ dev tun
 resolv-retry {{ openvpn_resolv_retry }}
 nobind
 keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
-{% if openvpn_compression is not none %}
+{% if openvpn_compression is undefined or openvpn_compression == "" %}
 compress {{ openvpn_compression }}
 {% endif %}
 persist-key

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -74,7 +74,7 @@ push "{{ opt }}"
 {% endfor %}
 {% endif %}
 keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
-{% if openvpn_compression %}
+{% if openvpn_compression is undefined or openvpn_compression == "" %}
 compress {{ openvpn_compression }}
 {% endif %}
 persist-key

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -74,7 +74,7 @@ push "{{ opt }}"
 {% endfor %}
 {% endif %}
 keepalive {{ openvpn_keepalive_ping }} {{ openvpn_keepalive_timeout }}
-{% if openvpn_compression is undefined or openvpn_compression == "" %}
+{% if openvpn_compression is not undefined and openvpn_compression != "" %}
 compress {{ openvpn_compression }}
 {% endif %}
 persist-key


### PR DESCRIPTION
It was not possible to disable compression fully in both server and client. This PR ensures you can properly disable the compression by setting `openvpn_compression: ""`.