### PR TITLE
tls_auth_required disabled for clients (solves #113)

### DIFF
--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -36,14 +36,18 @@ route-delay 2
 register-dns
 {% endif %}
 
+{% if tls_auth_required %}
 key-direction 1
+{% endif %}
 <ca>
 {{ ca_cert.content|b64decode }}
 </ca>
 
+{% if tls_auth_required %}
 <tls-auth>
 {{ tls_auth.content|b64decode }}
 </tls-auth>
+{% endif %}
 
 <cert>
 {{ item.0.content|b64decode }}


### PR DESCRIPTION
When `tls_auth_required` is `no` the output client VPN file changes according the setup
Solves #113  