### PR TITLE
Update cert_sync_detection.yml

### DIFF
--- a/tasks/cert_sync_detection.yml
+++ b/tasks/cert_sync_detection.yml
@@ -1,18 +1,18 @@
 ---
 - name: "[cert sync] Create temporary file for existing certs"
-  ansible.builtin.tempfile:
+  tempfile:
     state: file
     suffix: temp
   register: tempfile_existing
 
 - name: "[cert sync] Create temporary file for expected certs"
-  ansible.builtin.tempfile:
+  tempfile:
     state: file
     suffix: temp
   register: tempfile_expected
 
 - name: "[cert sync] Write expected client list to temp file for comparison with existing certs"
-  ansible.builtin.template:
+  template:
     src: cert_sync_expected_clients.j2
     dest: "{{ tempfile_expected.path }}"
     mode: 0644
@@ -39,7 +39,7 @@
   when: openvpn_cert_sync_revoke.stdout_lines | length > 0
 
 - name: "[cert sync] Cleanup temp files"
-  ansible.builtin.file:
+  file:
     path: "{{ item }}"
     state: absent
   with_items:


### PR DESCRIPTION
```
root@6554fa57bd5c:~# ansible-playbook -i "/path/to/hosts" "/path/to/my_playbook.yml"
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/root/.ansible/roles/kyl191.openvpn/tasks/cert_sync_detection.yml': line 14, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: "[cert sync] Write expected client list to temp file for comparison with existing certs"
  ^ here
```

the same result for all lines with `ansible.builtin.`