### PR TITLE
added 'auth' folder when compiling ldap plugin on centos 8

### DIFF
--- a/tasks/compile_ldap_plugin.yml
+++ b/tasks/compile_ldap_plugin.yml
@@ -14,6 +14,13 @@
     path: "{{ openvpn_auth_ldap_bin_path }}"
   register: openvpn_auth_ldap_bin
 
+- name: Ensure auth folder exist in openvpn dir
+  become: true
+  file:
+    path: "{{ openvpn_base_dir }}/auth"
+    state: directory
+    mode: 0755
+
 - block:
     - name: Install gcc objc repo
       become: true


### PR DESCRIPTION
When  compiling LDAP Plugin on Centos 8, the `auth` folder wasn't created and that cause the task `Install LDAP Config` to fail.

This simple PR ensure that the folder exist.