### PR TITLE
Correct support of LDAP on Ubuntu OS.

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -37,6 +37,19 @@
     mode: a+x
   when: openvpn_script_client_disconnect is defined
 
+- name: Ensure auth folder exist in openvpn dir
+  file:
+    path: "{{ openvpn_base_dir }}/auth"
+    state: directory
+    mode: 0755
+  when: openvpn_use_ldap
+
+- name: Delete auth folder in openvpn dir
+  file:
+    path: "{{ openvpn_base_dir }}/auth"
+    state: absent
+  when: not openvpn_use_ldap
+
 - name: Install LDAP config
   template:
     src: ldap.conf.j2

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,7 +28,7 @@
     state: present
   when:
     - openvpn_use_ldap
-    - ansible_distribution == "CentOS" and ansible_distribution_major_version != "8"
+    - ansible_distribution == "CentOS" and ansible_distribution_major_version != "8" or ansible_distribution != "CentOS"
 
 - name: Compile LDAP plugin
   include_tasks: compile_ldap_plugin.yml


### PR DESCRIPTION
* Correct condition of installation `openvpn-auth-ldap` package;
* Create and remove directory `/etc/openvpn/auth`, because in new version of package `openvpn-auth-ldap` directory `/etc/openvpn/auth` is not created from package.