### PR TITLE
feat: Update role to use ansible collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ OpenVPN must be available as a package in yum/dnf/apt! For CentOS users, this ro
 
 Ubuntu precise has a [weird bug](https://bugs.launchpad.net/ubuntu/+source/iptables-persistent/+bug/1002078) that might make the iptables-persistent install fail. There is a [workaround](https://forum.linode.com/viewtopic.php?p=58233#p58233).
 
+## Ansible 2.10 and higher
+With the release of Ansible 2.10, modules have been moved into collections. With the exception of ansible.builtin modules, this means additonal collections must be installed in order to use modules such as seboolean (now ansible.posix.seboolean). This collections is now required: `ansible.posix` and this collection is required if using ufw: `community.general`. Installing the collections:
+
+```
+ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install community.general
+```
+
 # Support Notes/Expectations
 I personally use this role to manage OpenVPN on CentOS 8. I try to keep the role on that platform fully functional with the default config.
 Please recognise that I am a single person, and I have a full time job and other commitments.

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -15,7 +15,7 @@
     - ansible_python.version.major == 2
 
 - name: Enable OpenVPN Port (firewalld)
-  firewalld:
+  ansible.posix.firewalld:
     port: "{{ openvpn_port }}/{{ openvpn_proto }}"
     zone: "{{ firewalld_default_interface_zone }}"
     permanent: true
@@ -23,7 +23,7 @@
     state: enabled
 
 - name: Set tun0 interface to internal
-  firewalld:
+  ansible.posix.firewalld:
     interface: tun0
     zone: internal
     permanent: true
@@ -31,7 +31,7 @@
     state: enabled
 
 - name: Set default interface to external
-  firewalld:
+  ansible.posix.firewalld:
     interface: "{{ ansible_default_ipv4.interface }}"
     zone: "{{ firewalld_default_interface_zone }}"
     permanent: true
@@ -39,7 +39,7 @@
     state: enabled
 
 - name: Enable masquerading on external zone
-  firewalld:
+  ansible.posix.firewalld:
     masquerade: true
     zone: "{{ firewalld_default_interface_zone }}"
     permanent: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
 # ignoreerrors is required for CentOS/RHEL 6
 # http://serverfault.com/questions/477718/sysctl-p-etc-sysctl-conf-returns-error
 - name: Enable ipv4 forwarding
-  sysctl:
+  ansible.posix.sysctl:
     name: net.ipv4.ip_forward
     value: '1'
     ignoreerrors: true
@@ -33,7 +33,7 @@
   when: not ci_build
 
 - name: Enable ipv6 forwarding
-  sysctl:
+  ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
     value: '1'
     ignoreerrors: true

--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -6,7 +6,7 @@
     state: started
 
 - name: Enable ufw
-  ufw:
+  community.general.ufw:
     direction: incoming
     state: enabled
     policy: allow
@@ -18,14 +18,14 @@
     line: DEFAULT_FORWARD_POLICY="ACCEPT"
 
 - name: Allow incoming VPN connections - ufw
-  ufw:
+  community.general.ufw:
     direction: in
     proto: "{{ openvpn_proto }}"
     to_port: "{{ openvpn_port | string }}"
     rule: allow
 
 - name: Accept packets from VPN tunnel adaptor - ufw
-  ufw:
+  community.general.ufw:
     direction: in
     interface: tun0
     rule: allow


### PR DESCRIPTION
Updated the role to work with Ansible 2.10 and higher by specifying the collections for tasks that are not part of ansible.builtin.  Namely sysctl (tasks/main.yml), firewalld (tasks/firewalld.yml), and ufw (tasks/ufw.yml).  Updated the readme to indicate the new requirements.