### PR TITLE
Fix periodic update of the CRL

### DIFF
--- a/templates/crl-cron.sh.j2
+++ b/templates/crl-cron.sh.j2
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-lastUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -noout -lastupdate | cut -d'=' -f2)" +%s)
 nextUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -noout -nextupdate | cut -d'=' -f2)" +%s)
+now=$(date +%s)
 
-if [ $(( (nextUpdate - lastUpdate) / 86400 )) -le 10 ]; then
+if [ $(( (nextUpdate - now) / 86400 )) -le 10 ]; then
     sh {{ openvpn_key_dir }}/revoke.sh
 fi


### PR DESCRIPTION
Check, if the CRL expires soon instead of comparing the last and next update times. This will actually prevent, that the CRL expires.

Should fix #145.