### PR TITLE
Fix CI & lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: check-syntax
     container:
-      image: diodonfrost/ansible-fedora:34
+      image: diodonfrost/ansible-fedora:35
       env:
         container: docker
       volumes:
@@ -26,6 +26,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Setup ansible.posix collection for firewalld
+        run: ansible-galaxy collection install ansible.posix
+      - name: Setup community.general collection for ufw
+        run: ansible-galaxy collection install community.general
       - name: Check syntax of ansible playbook
         run: ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml --syntax-check
 
@@ -38,9 +42,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "32"
           - "33"
           - "34"
+          - "35"
 
     container:
       image: diodonfrost/ansible-fedora:${{ matrix.version }}
@@ -53,6 +57,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Setup ansible.posix collection for firewalld
+        run: ansible-galaxy collection install ansible.posix
+      - name: Setup community.general collection for ufw
+        run: ansible-galaxy collection install community.general
       - name: Make sure ansible connection is sane
         run: ansible -m setup -c local -i 127.0.0.1, all
       - name: Run ansible playbook
@@ -91,6 +99,51 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Setup ansible.posix collection for firewalld
+        run: ansible-galaxy collection install ansible.posix
+      - name: Setup community.general collection for ufw
+        run: ansible-galaxy collection install community.general
+      - name: Make sure ansible connection is sane
+        run: ansible -m setup -c local -i 127.0.0.1, all
+      - name: Run ansible playbook
+        run: ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml -vv
+      - name: Check idempotency
+        run: ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml -vv
+      - name: Container state debug output
+        continue-on-error: true
+        run: |
+          ls -lR /etc/openvpn
+          echo "cat openvpn_udp_1194.conf"
+          find /etc/openvpn/ -maxdepth 3 -name openvpn_udp_1194.conf -type f -exec cat {} \;
+          echo "cat alpha-*.ovpn"
+          find /etc/openvpn/ -maxdepth 3 -name "alpha-*.ovpn" -type f -exec cat {} \;
+
+  build-rocky:
+    runs-on: ubuntu-20.04
+    name: rocky-${{ matrix.version }}
+    needs:
+      - check-syntax
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "8"
+
+    container:
+      image: diodonfrost/ansible-rockylinux:${{ matrix.version }}
+      env:
+        container: docker
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+        - ${{ github.workspace }}:/etc/ansible/roles/ansible-role-openvpn
+      options: "--cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/net/tun"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup ansible.posix collection for firewalld
+        run: ansible-galaxy collection install ansible.posix
+      - name: Setup community.general collection for ufw
+        run: ansible-galaxy collection install community.general
       - name: Make sure ansible connection is sane
         run: ansible -m setup -c local -i 127.0.0.1, all
       - name: Run ansible playbook

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -31,21 +31,21 @@
   when: firewalld.rc != 0 and ufw.rc != 0 and iptables.rc != 0
 
 - name: Add port rules (iptables)
-  include: iptables.yml
+  include_tasks: iptables.yml
   when: >-
     (openvpn_firewall == 'iptables')
     or
     (openvpn_firewall == 'auto' and firewalld.rc != 0 and ufw.rc != 0 and iptables.rc == 0)
 
 - name: Add port rules (firewalld)
-  include: firewalld.yml
+  include_tasks: firewalld.yml
   when: >-
     (openvpn_firewall == 'firewalld')
     or
     (openvpn_firewall == 'auto' and firewalld.rc == 0 and ufw.rc != 0)
 
 - name: Add port rules (ufw)
-  include: ufw.yml
+  include_tasks: ufw.yml
   when: >-
     (openvpn_firewall == 'ufw')
     or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
     - firewall
 
 - name: Configure SELinux
-  include: selinux.yml
+  import_tasks: selinux.yml
   when:
     - ansible_selinux.status == "enabled"
 


### PR DESCRIPTION
* Add new ansible-galaxy collections
* Support Fedora 35 & RockyLinux 8, drop Fedora 32
* Replace include with import_tasks to stop the deprecation warning