### PR TITLE
Make openvpn_custom_dns work as defined in Readme

### DIFF
--- a/defaults/main/openvpn.yml
+++ b/defaults/main/openvpn.yml
@@ -5,7 +5,6 @@
 openvpn_client_register_dns: true
 openvpn_client_to_client: false
 openvpn_custom_dns: []
-openvpn_dns_servers: []
 openvpn_dualstack: true
 openvpn_keepalive_ping: 5
 openvpn_keepalive_timeout: 30

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -60,8 +60,8 @@ client-config-dir {{ openvpn_client_config_dir }}
 push "redirect-gateway def1 bypass-dhcp"
 {% endif %}
 {% if openvpn_set_dns %}
-{% if openvpn_custom_dns %}
-{% for srv in openvpn_dns_servers %}
+{% if openvpn_custom_dns|length > 0 %}
+{% for srv in openvpn_custom_dns %}
 push "dhcp-option DNS {{ srv }}"
 {% endfor %}
 {% else %}


### PR DESCRIPTION
Hello,

I was using `openvpn_custom_dns` along with `openvpn_set_dns` as `true` and noticed it wasn't adding the servers to my openvpn config.

Looking at the code it previously treated `openvpn_custom_dns` as if it was a Boolean, and instead used `openvpn_dns_servers` to loop through the servers:
```
{% if openvpn_set_dns %}
{% if openvpn_custom_dns %}
{% for srv in openvpn_dns_servers %}
push "dhcp-option DNS {{ srv }}"
```

It seemed to be suggesting that in our configs we set:
```
openvpn_set_dns: true
openvpn_custom_dns: true
openvpn_dns_servers:
 - 8.8.8.8
 - 8.8.4.4
```
Which contradicted the docs which state:
<img width="690" alt="Screenshot 2022-01-25 at 10 05 47" src="https://user-images.githubusercontent.com/8949315/150956060-c5a8729c-f7d3-42c8-8be3-36d63f9846a4.png">


---
I've tried to change it so we don't use `openvpn_dns_servers` at all, and the check for if we either add custom-servers vs the default DNS is based entirely on whether or not `openvpn_custom_dns` has entries in it.
This makes it more in-line with what the README says

# Potentially breaking changes
* If people have themselves been using the undocumented `openvpn_dns_servers` (and `openvpn_custom_dns`:`true`) it will no longer work
* If people have been passing a bad list to `openvpn_custom_dns` without it actually writing them to config previously, it would now actually insert them which could potentially break