### PR TITLE
Add LDAP integration for RedHat

### DIFF
--- a/tasks/compile_ldap_plugin.yml
+++ b/tasks/compile_ldap_plugin.yml
@@ -73,7 +73,7 @@
             mode: 0750
             state: directory
 
-        # This is fixing 
+        # This is fixing https://github.com/threerings/openvpn-auth-ldap/pull/85
         - name: Change configure.ac
           lineinfile:
             path: "{{ compile_source_dir }}/openvpn-auth-ldap-auth-ldap-{{ openvpn_auth_ldap_version }}/configure.ac"
@@ -81,7 +81,7 @@
             line: AC_PROG_CC(clang gobjc)
           when: ansible_os_family == 'RedHat'
 
-        # This is fixing 
+        # This is fixing https://github.com/threerings/openvpn-auth-ldap/pull/85
         - name: Change configure.ac
           lineinfile:
             path: "{{ compile_source_dir }}/openvpn-auth-ldap-auth-ldap-{{ openvpn_auth_ldap_version }}/configure.ac"

--- a/tasks/compile_ldap_plugin.yml
+++ b/tasks/compile_ldap_plugin.yml
@@ -52,7 +52,7 @@
             chdir: "{{ compile_source_dir }}/re2c-{{ re2c_version }}"
             creates: "{{ re2c_bin_path }}"
       when:
-        - re2c_bin.stat.exists
+        - not re2c_bin.stat.exists
 
     - name: Install openvpn-auth-ldap
       block:

--- a/tasks/compile_ldap_plugin.yml
+++ b/tasks/compile_ldap_plugin.yml
@@ -52,7 +52,7 @@
             chdir: "{{ compile_source_dir }}/re2c-{{ re2c_version }}"
             creates: "{{ re2c_bin_path }}"
       when:
-        - not re2c_bin.stat.exists
+        - re2c_bin.stat.exists
 
     - name: Install openvpn-auth-ldap
       block:
@@ -73,10 +73,26 @@
             mode: 0750
             state: directory
 
+        # This is fixing 
+        - name: Change configure.ac
+          lineinfile:
+            path: "{{ compile_source_dir }}/openvpn-auth-ldap-auth-ldap-{{ openvpn_auth_ldap_version }}/configure.ac"
+            regexp: '^AC_PROG_CC\('
+            line: AC_PROG_CC(clang gobjc)
+          when: ansible_os_family == 'RedHat'
+
+        # This is fixing 
+        - name: Change configure.ac
+          lineinfile:
+            path: "{{ compile_source_dir }}/openvpn-auth-ldap-auth-ldap-{{ openvpn_auth_ldap_version }}/configure.ac"
+            regexp: '^AC_PROG_OBJC\('
+            line: AC_PROG_OBJC(clang gobjc)
+          when: ansible_os_family == 'RedHat'
+
         - name: Compile
           become: true
           environment:
-            PATH: "{{ re2c_bin_path | dirname }}:{{ lookup('env', 'PATH') }}"
+            PATH: "{{ re2c_bin_path | dirname }}:{{ lookup('env', 'PATH') }}:/bin"
           shell: |
             autoconf
             autoheader

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,13 +51,13 @@
     state: present
   when:
     - openvpn_use_ldap
-    - ansible_distribution == "CentOS" and ansible_distribution_major_version != "8" or ansible_distribution != "CentOS"
+    - ansible_distribution == "CentOS" or ansible_distribution == "RedHat" and ansible_distribution_major_version != "8" or ansible_distribution != "CentOS"
 
 - name: Compile LDAP plugin
   include_tasks: compile_ldap_plugin.yml
   when:
     - openvpn_use_ldap
-    - ansible_distribution == "CentOS" and ansible_distribution_major_version == "8"
+    - ansible_distribution == "CentOS"  or ansible_distribution == "RedHat" and ansible_distribution_major_version == "8"
 
 # RHEL has the group 'nobody', 'Debian/Ubuntu' have 'nogroup'
 # standardize on 'nogroup'


### PR DESCRIPTION
Currently, for RHEL (I've tested it on 8.4) the LDAP integration is working. During compiling, we have to adjust the compiler due to the limitation that RedHat ended the support for Objective-C (mentioned here https://github.com/threerings/openvpn-auth-ldap/pull/85).