### PR TITLE
Revocation: Also remove client cert

### DIFF
--- a/tasks/revocation.yml
+++ b/tasks/revocation.yml
@@ -34,3 +34,12 @@
   with_items:
     - '{{ openvpn_revoke_these_certs }}'
     - '{{ openvpn_cert_sync_revoke | default([]) }}'
+
+- name: Remove client cert
+  file:
+    path: "{{ openvpn_key_dir }}/{{ item }}.crt"
+    state: absent
+    force: true
+  with_items:
+    - '{{ openvpn_revoke_these_certs }}'
+    - '{{ openvpn_cert_sync_revoke | default([]) }}'


### PR DESCRIPTION
When re-adding a client with the same name, a new key will be generated because the key file was deleted during revocation. But no new and therefore matching certificate will be generated because that file still exists. The result will be a .ovpn file with mismatching key and cert.