### PR TITLE
Firewall: Use the right IP subnet

### DIFF
--- a/defaults/main/openvpn.yml
+++ b/defaults/main/openvpn.yml
@@ -15,6 +15,7 @@ openvpn_resolv_retry: 5
 openvpn_server_hostname: "{{ inventory_hostname }}"
 openvpn_server_netmask: 255.255.255.0
 openvpn_server_network: 10.9.0.0
+openvpn_server_netmask_cidr: "{{ (openvpn_server_network + '/' + openvpn_server_netmask) | ansible.utils.ipaddr('prefix') }}"
 openvpn_set_dns: true
 openvpn_tun_mtu:
 
@@ -43,7 +44,6 @@ openvpn_push: []
 openvpn_service_group: nogroup
 openvpn_service_user: nobody
 openvpn_status_version: 1
-
 
 # Client config - settings the server will push
 openvpn_client_config: false

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -25,7 +25,7 @@
 - name: Allow VPN forwarding - iptables
   iptables:
     chain: FORWARD
-    source: "{{ openvpn_server_network }}/24"
+    source: "{{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
     jump: ACCEPT
     action: insert
     comment: "Allow VPN forwarding"
@@ -64,7 +64,7 @@
   iptables:
     table: nat
     chain: POSTROUTING
-    source: "{{ openvpn_server_network }}/24"
+    source: "{{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
     to_source: "{{ ansible_default_ipv4.address }}"
     jump: SNAT
     action: insert
@@ -76,7 +76,7 @@
   iptables:
     table: nat
     chain: POSTROUTING
-    source: "{{ openvpn_server_network }}/24"
+    source: "{{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
     jump: MASQUERADE
     action: insert
     comment: "Perform NAT readdressing"

--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -39,7 +39,7 @@
       # OpenVPN config
       *nat
       :POSTROUTING ACCEPT [0:0]
-      -A POSTROUTING -s {{ openvpn_server_network }}/24 -j SNAT --to-source {{ ansible_default_ipv4.address }}
+      -A POSTROUTING -s {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }} -j SNAT --to-source {{ ansible_default_ipv4.address }}
       COMMIT
   when: not openvpn_masquerade_not_snat
   notify:
@@ -54,7 +54,7 @@
       # OpenVPN config
       *nat
       :POSTROUTING ACCEPT [0:0]
-      -A POSTROUTING -s {{ openvpn_server_network }}/24 -j MASQUERADE
+      -A POSTROUTING -s {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }} -j MASQUERADE
       COMMIT
   when: openvpn_masquerade_not_snat
   notify:


### PR DESCRIPTION
The firewall rules always use a /24 subnet, even if something else was configured in the "openvpn_server_netmask" parameter. This PR uses some ipaddr filter magic to extract the CIDR prefix length from the two netmask and network variables.

This change was originally proposed in #163, but wasn't merged because of the other changes in that PR.