### PR TITLE
Redirect stderr to /dev/null when regenerating the CRL from cron

### DIFF
--- a/templates/crl-cron.sh.j2
+++ b/templates/crl-cron.sh.j2
@@ -4,5 +4,5 @@ nextUpdate=$(date --date "$(openssl crl -in {{ openvpn_key_dir }}/ca-crl.pem -no
 now=$(date +%s)
 
 if [ $(( (nextUpdate - now) / 86400 )) -le 10 ]; then
-    sh {{ openvpn_key_dir }}/revoke.sh
+    sh {{ openvpn_key_dir }}/revoke.sh 2>/dev/null
 fi


### PR DESCRIPTION
Fixes #199.

Instead of redirecting in the revoke.sh script, redirect from the script that cron runs since that's the main concern.

Tested locally
```
[root@stream9 keys]# ./revoke.sh
Using configuration from ca.conf
[root@stream9 keys]# ./revoke.sh 2>/dev/null
[root@stream9 keys]# echo $? 
0
```