### PR TITLE
Add systemd override for openvpn

### DIFF
--- a/files/openvpn-server-override.conf
+++ b/files/openvpn-server-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/openvpn --config %i.conf

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -115,6 +115,22 @@
     state: absent
   when: openvpn_client_config is falsy
 
+- name: Create openvpn service override
+  when: ansible_service_mgr == "systemd"
+  block:
+    - name: Create openvpn service override directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/openvpn-server@.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+    - name: Copy openvpn service override file
+      ansible.builtin.copy:
+        src: openvpn-server-override.conf
+        dest: /etc/systemd/system/openvpn-server@.service.d/override.conf
+        mode: "0644"
+
 - name: Setup openvpn auto-start & start
   ansible.builtin.service:
     name: "{{ openvpn_service_name }}"


### PR DESCRIPTION
CentOS and Fedora override the ciphers on the command line in the unit file: https://src.fedoraproject.org/rpms/openvpn/blob/rawhide/f/0001-Change-the-default-cipher-to-AES-256-GCM-for-server-.patch

This ignores the settings in the config file, so place a systemd override file that strips all of the command line options.

Tested locally:
```
[root@alma9 ~]# systemctl status openvpn-server@openvpn_tcp_443.service
● openvpn-server@openvpn_tcp_443.service - OpenVPN service for openvpn_tcp_443
     Loaded: loaded (/usr/lib/systemd/system/openvpn-server@.service; enabled; preset: disabled)
    Drop-In: /etc/systemd/system/openvpn-server@.service.d
             └─override.conf
...
     CGroup: /system.slice/system-openvpn\x2dserver.slice/openvpn-server@openvpn_tcp_443.service
             └─964 /usr/sbin/openvpn --config openvpn_tcp_443.conf
```