### PR TITLE
Add ansible-lint configuration to enforce variable naming convention

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,7 +1,7 @@
 ---
 profile: production
 loop_var_prefix: "^(__|{role}_)"
-var_naming_pattern: "^[a-z_][a-z0-9_]*$"
+var_naming_pattern: "^(_|openvpn)_[a-z_][a-z0-9_]*|^.*_package_name$"
 
 enable_list:
   - args

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,9 +218,9 @@ jobs:
       - name: Make sure ansible connection is sane
         run: sudo podman exec ${{ matrix.version }} ansible -m setup -c local -i 127.0.0.1, all
       - name: Run ansible playbook
-        run: sudo podman exec ${{ matrix.version }} ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml -vv -e ci_build=False
+        run: sudo podman exec ${{ matrix.version }} ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml -vv -e openvpn_ci_build=False
       - name: Check idempotency
-        run: sudo podman exec ${{ matrix.version }} ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml -vv
+        run: sudo podman exec ${{ matrix.version }} ansible-playbook /etc/ansible/roles/ansible-role-openvpn/tests/test.yml -vv -e openvpn_ci_build=False
       - name: Move generated client config file
         run: sudo podman exec ${{ matrix.version }} cp /etc/openvpn/server/alpha-localhost.ovpn /etc/openvpn/client/alpha-localhost.conf
       - name: Attempt openvpn connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Notable variable changes include:
   * `ldap` dict becoming `openvpn_ldap`
   * `tls_auth_required` becoming `openvpn_tls_auth_required`
   * `manage_firewall_rules` becoming `openvpn_manage_firewall_rules`
+  * `iptables_service` becoming `openvpn_iptables_service`
 
 ## Changed Supported OS Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ansible-lint isn't complaining anymore. It's also added to the CI system so the 
 Notable variable changes include:
   * `ldap` dict becoming `openvpn_ldap`
   * `tls_auth_required` becoming `openvpn_tls_auth_required`
+  * `manage_firewall_rules` becoming `openvpn_manage_firewall_rules`
 
 ## Changed Supported OS Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ansible-lint isn't complaining anymore. It's also added to the CI system so the 
 * I've converted to using `truthy/falsy` instead of inconsistenly using `|bool` for boolean comparisons.
 * Variables are prefixed with `openvpn_` to make sure they are isolated to this role. (There are [limited exceptions](.ansible-lint.yml))
 Notable variable changes include:
+  * `clients` becoming `openvpn_clients`
   * `ldap` dict becoming `openvpn_ldap`
   * `tls_auth_required` becoming `openvpn_tls_auth_required`
   * `manage_firewall_rules` becoming `openvpn_manage_firewall_rules`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ansible-lint isn't complaining anymore. It's also added to the CI system so the 
 * Variables are prefixed with `openvpn_` to make sure they are isolated to this role. (There are [limited exceptions](.ansible-lint.yml))
 Notable variable changes include:
   * `ldap` dict becoming `openvpn_ldap`
+  * `tls_auth_required` becoming `openvpn_tls_auth_required`
 
 ## Changed Supported OS Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Updated to latest Ansible recommendations
 
-ansible-lint isn't complaining anymore. It's also added to the CI system so the role shouldn't regress.
+ansible-lint isn't complaining anymore. It's also added to the CI system so the role shouldn't regress. A few more changes:
 
-I've also added `truthy/falsy` to clauses to make sure a value is always coerced to a bool.
+* I've converted to using `truthy/falsy` instead of inconsistenly using `|bool` for boolean comparisons.
+* Variables are prefixed with `openvpn_` to make sure they are isolated to this role. (There are [limited exceptions](.ansible-lint.yml))
+Notable variable changes include:
+  * `ldap` dict becoming `openvpn_ldap`
 
 ## Changed Supported OS Versions
 
@@ -57,9 +60,7 @@ Discussion in [this issue](https://github.com/kyl191/ansible-role-openvpn/issues
 
 ## LDAP plugin no longer built by default
 
-This thing has honestly made me nervous since merging it because I don't have anything that uses LDAP. I trust that it functions, but [a compliation issue was reported](https://github.com/kyl191/ansible-role-openvpn/issues/174).
-
-Turns out Fedora/EPEL, Debian, and Ubuntu all provide packages for openvpn-auth-ldap so I'm dropping the compilation step to simplify the role.
+This thing has honestly made me nervous since merging it because it's rather complicated. [A compliation issue was reported](https://github.com/kyl191/ansible-role-openvpn/issues/174), and Fedora/EPEL, Debian, and Ubuntu all provide packages for openvpn-auth-ldap so I'm dropping the compilation step to simplify the role.
 
 * Fedora/EPEL: <https://packages.fedoraproject.org/pkgs/openvpn-auth-ldap/openvpn-auth-ldap/index.html>
 * Debian: <https://packages.debian.org/search?keywords=openvpn-auth-ldap>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Change these options if you need to force a particular firewall or change how th
 | Variable                         | Type    | Choices                        | Default  | Comment                                                                                                     |
 |----------------------------------|---------|--------------------------------|----------|-------------------------------------------------------------------------------------------------------------|
 | openvpn_firewalld_default_interface_zone | string  |                                | public   | Firewalld zone where the "ansible_default_ipv4.interface" will be pushed into                               |
-| iptables_service                 | string  |                                | iptables | Override the iptables service name                                                                          |
+| openvpn_iptables_service                 | string  |                                | iptables | Override the iptables service name                                                                          |
 | openvpn_manage_firewall_rules            | boolean | true, false                    | true     | Allow playbook to manage iptables                                                                           |
 | openvpn_firewall                 | string  | auto, firewalld, ufw, iptables | auto     | The firewall software to configure network rules. "auto" will attempt to detect it by inspecting the system |
 | openvpn_masquerade_not_snat      | boolean | true, false                    | false    | Set to true if you want to set up MASQUERADE instead of the default SNAT in iptables.                       |

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This role pulls in a bunch of different packages. Override the names as necessar
 
 | Variable            | Type   | Choices                   | Default                                 | Comment                                                                                      |
 |---------------------|--------|---------------------------|-----------------------------------------|----------------------------------------------------------------------------------------------|
-| ldap                | dict   |                           |                                         | Dictionary that contain LDAP configuration                                                   |
+| openvpn_ldap                | dict   |                           |                                         | Dictionary that contain LDAP configuration                                                   |
 | url                 | string |                           | ldap://host.example.com                 | Address of you LDAP backend with syntax ldap[s]://host[:port]                                |
 | anonymous_bind      | string | False , True              | False                                   | This is not an Ansible boolean but a string that will be pushed into the configuration file. |
 | bind_dn             | string |                           | uid=Manager,ou=People,dc=example,dc=com | Bind DN used if "anonymous_bind" set to "False"                                              |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ These options change how OpenVPN itself works.
 | openvpn_use_modern_tls             | boolean | true, false | true        | Use modern Cipher for TLS encryption (Not recommended with OpenVPN 2.4)                                                                                         |
 | openvpn_use_pregenerated_dh_params | boolean | true, false | false       | DH params are generted with the install by default                                                                                                              |
 | openvpn_verify_cn                  | boolean | true, false | false       | Check that the CN of the certificate match the FQDN                                                                                                             |
-| tls_auth_required                  | boolean | true, false | true        | Ask the client to push the generated ta.key of the server during the connection                                                                                 |
+| openvpn_tls_auth_required                  | boolean | true, false | true        | Ask the client to push the generated ta.key of the server during the connection                                                                                 |
 
 ### Operations
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Change these options if you need to force a particular firewall or change how th
 
 | Variable                         | Type    | Choices                        | Default  | Comment                                                                                                     |
 |----------------------------------|---------|--------------------------------|----------|-------------------------------------------------------------------------------------------------------------|
-| firewalld_default_interface_zone | string  |                                | public   | Firewalld zone where the "ansible_default_ipv4.interface" will be pushed into                               |
+| openvpn_firewalld_default_interface_zone | string  |                                | public   | Firewalld zone where the "ansible_default_ipv4.interface" will be pushed into                               |
 | iptables_service                 | string  |                                | iptables | Override the iptables service name                                                                          |
 | manage_firewall_rules            | boolean | true, false                    | true     | Allow playbook to manage iptables                                                                           |
 | openvpn_firewall                 | string  | auto, firewalld, ufw, iptables | auto     | The firewall software to configure network rules. "auto" will attempt to detect it by inspecting the system |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Change these options if you need to force a particular firewall or change how th
 |----------------------------------|---------|--------------------------------|----------|-------------------------------------------------------------------------------------------------------------|
 | openvpn_firewalld_default_interface_zone | string  |                                | public   | Firewalld zone where the "ansible_default_ipv4.interface" will be pushed into                               |
 | iptables_service                 | string  |                                | iptables | Override the iptables service name                                                                          |
-| manage_firewall_rules            | boolean | true, false                    | true     | Allow playbook to manage iptables                                                                           |
+| openvpn_manage_firewall_rules            | boolean | true, false                    | true     | Allow playbook to manage iptables                                                                           |
 | openvpn_firewall                 | string  | auto, firewalld, ufw, iptables | auto     | The firewall software to configure network rules. "auto" will attempt to detect it by inspecting the system |
 | openvpn_masquerade_not_snat      | boolean | true, false                    | false    | Set to true if you want to set up MASQUERADE instead of the default SNAT in iptables.                       |
 

--- a/defaults/main/ldap.yml
+++ b/defaults/main/ldap.yml
@@ -1,5 +1,5 @@
 ---
-ldap:
+openvpn_ldap:
   url: ldap://host.example.com
   anonymous_bind: false
   bind_dn: uid=Manager,ou=People,dc=example,dc=com

--- a/defaults/main/openvpn.yml
+++ b/defaults/main/openvpn.yml
@@ -29,7 +29,7 @@ openvpn_use_hardened_tls: true
 openvpn_use_modern_tls: true
 openvpn_use_pregenerated_dh_params: false
 openvpn_verify_cn: false
-tls_auth_required: true
+openvpn_tls_auth_required: true
 openvpn_script_security: 1
 
 # Operations

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults for the role operation
 
-clients: []
+openvpn_clients: []
 # Directories
 # Fedora, CentOS 8+, Debian and Ubuntu separate OpenVPN into client and server
 # /lib/systemd/system/openvpn-server@.service and /lib/systemd/system/openvpn-client@.service

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -17,7 +17,7 @@ openvpn_fetch_client_configs_suffix: ""
 
 # Firewall
 openvpn_firewalld_default_interface_zone: public
-iptables_service: iptables
+openvpn_iptables_service: iptables
 openvpn_manage_firewall_rules: true
 openvpn_firewall: auto
 openvpn_masquerade_not_snat: false

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -18,7 +18,7 @@ openvpn_fetch_client_configs_suffix: ""
 # Firewall
 openvpn_firewalld_default_interface_zone: public
 iptables_service: iptables
-manage_firewall_rules: true
+openvpn_manage_firewall_rules: true
 openvpn_firewall: auto
 openvpn_masquerade_not_snat: false
 openvpn_no_nat: false

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -16,7 +16,7 @@ openvpn_fetch_client_configs_dir: /tmp/ansible
 openvpn_fetch_client_configs_suffix: ""
 
 # Firewall
-firewalld_default_interface_zone: public
+openvpn_firewalld_default_interface_zone: public
 iptables_service: iptables
 manage_firewall_rules: true
 openvpn_firewall: auto

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -24,7 +24,7 @@ openvpn_masquerade_not_snat: false
 openvpn_no_nat: false
 
 # Misc
-ci_build: false
+openvpn_ci_build: false
 openvpn_conf_user: root
 openvpn_conf_group: root
 openvpn_script_user: root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,7 +22,7 @@
     state: restarted
 
 - name: Save iptables rules (Debian/Ubuntu and CentOS/RHEL/Fedora)
-  ansible.builtin.shell: "{{ iptables_save_command }}" # noqa command-instead-of-shell could have shell redirection
+  ansible.builtin.shell: "{{ __iptables_save_command }}" # noqa command-instead-of-shell could have shell redirection
   when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'
   listen: "Save iptables"
   changed_when: true # always save iptables rules

--- a/tasks/cert_sync_detection.yml
+++ b/tasks/cert_sync_detection.yml
@@ -18,7 +18,7 @@
 # Make difference between 2 list to have only cert to revoke
 - name: "cert_sync_detection | Create list of cert to revoke"
   ansible.builtin.set_fact:
-    openvpn_cert_sync_revoke: "{{ (openvpn_existing_client | default([])) | difference(clients | sort) }}"
+    openvpn_cert_sync_revoke: "{{ (openvpn_existing_client | default([])) | difference(openvpn_clients | sort) }}"
 
 - name: "cert_sync_detection | Debug: Certs to revoke (skipped if none)"
   ansible.builtin.debug:

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -21,14 +21,14 @@
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ item }}.key"
   with_items:
-    - "{{ clients }}"
+    - "{{ openvpn_clients }}"
 
 - name: client_keys | Protect client keys
   ansible.builtin.file:
     path: "{{ openvpn_key_dir }}/{{ item }}.key"
     mode: "0400"
   with_items:
-    - "{{ clients }}"
+    - "{{ openvpn_clients }}"
 
 - name: client_keys | Sign client key
   ansible.builtin.command: openssl x509 -req -in {{ item }}.csr -out {{ item }}.crt -CA ca.crt -CAkey ca-key.pem -sha256 -days 3650 -extfile openssl-client.ext
@@ -36,7 +36,7 @@
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ item }}.crt"
   with_items:
-    - "{{ clients }}"
+    - "{{ openvpn_clients }}"
 
 - name: client_keys | Register server ca key
   ansible.builtin.slurp:
@@ -52,14 +52,14 @@
   ansible.builtin.slurp:
     src: "{{ openvpn_key_dir }}/{{ item }}.crt"
   with_items:
-    - "{{ clients }}"
+    - "{{ openvpn_clients }}"
   register: __client_certs
 
 - name: client_keys | Register client keys
   ansible.builtin.slurp:
     src: "{{ openvpn_key_dir }}/{{ item }}.key"
   with_items:
-    - "{{ clients }}"
+    - "{{ openvpn_clients }}"
   register: __client_keys
 
 - name: client_keys | Generate client config
@@ -81,4 +81,4 @@
     flat: true
   when: openvpn_fetch_client_configs is truthy
   with_items:
-    - "{{ clients }}"
+    - "{{ openvpn_clients }}"

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -41,26 +41,26 @@
 - name: client_keys | Register server ca key
   ansible.builtin.slurp:
     src: "{{ openvpn_key_dir }}/ca.crt"
-  register: ca_cert
+  register: __ca_cert
 
 - name: client_keys | Register tls-auth key
   ansible.builtin.slurp:
     src: "{{ openvpn_key_dir }}/ta.key"
-  register: tls_auth
+  register: __tls_auth
 
 - name: client_keys | Register client certs
   ansible.builtin.slurp:
     src: "{{ openvpn_key_dir }}/{{ item }}.crt"
   with_items:
     - "{{ clients }}"
-  register: client_certs
+  register: __client_certs
 
 - name: client_keys | Register client keys
   ansible.builtin.slurp:
     src: "{{ openvpn_key_dir }}/{{ item }}.key"
   with_items:
     - "{{ clients }}"
-  register: client_keys
+  register: __client_keys
 
 - name: client_keys | Generate client config
   no_log: "{{ openvpn_client_config_no_log }}"
@@ -71,8 +71,8 @@
     group: "{{ openvpn_conf_group }}"
     mode: "0400"
   with_together:
-    - "{{ client_certs.results }}"
-    - "{{ client_keys.results }}"
+    - "{{ __client_certs.results }}"
+    - "{{ __client_keys.results }}"
 
 - name: client_keys | Fetch client config
   ansible.builtin.fetch:

--- a/tasks/firewall/firewall.yml
+++ b/tasks/firewall/firewall.yml
@@ -1,21 +1,21 @@
 ---
 - name: firewall | firewall | Check for firewalld
   ansible.builtin.command: which firewall-cmd
-  register: firewalld
+  register: __firewalld
   check_mode: false
   changed_when: false # Never report as changed
   failed_when: false
 
 - name: firewall | firewall | Check for ufw
   ansible.builtin.command: which ufw
-  register: ufw
+  register: __ufw
   check_mode: false
   changed_when: false # Never report as changed
   failed_when: false
 
 - name: firewall | firewall | Check for iptables
   ansible.builtin.command: which iptables
-  register: iptables
+  register: __iptables
   check_mode: false
   changed_when: false # Never report as changed
   failed_when: false
@@ -23,30 +23,30 @@
 - name: firewall | firewall | Fail on both firewalld & ufw
   ansible.builtin.fail:
     msg: "Both FirewallD and UFW are detected, firewall situation is unknown"
-  when: openvpn_firewall == 'auto' and firewalld.rc == 0 and ufw.rc == 0
+  when: openvpn_firewall == 'auto' and __firewalld.rc == 0 and __ufw.rc == 0
 
 - name: firewall | firewall | Fail on no firewall detected
   ansible.builtin.fail:
     msg: "No firewall detected, install one before proceeding (firewalld||ufw||iptables)"
-  when: firewalld.rc != 0 and ufw.rc != 0 and iptables.rc != 0
+  when: __firewalld.rc != 0 and __ufw.rc != 0 and __iptables.rc != 0
 
 - name: firewall | firewall | Add port rules (iptables)
   ansible.builtin.include_tasks: iptables.yml
   when: >-
     (openvpn_firewall == 'iptables')
     or
-    (openvpn_firewall == 'auto' and firewalld.rc != 0 and ufw.rc != 0 and iptables.rc == 0)
+    (openvpn_firewall == 'auto' and __firewalld.rc != 0 and __ufw.rc != 0 and __iptables.rc == 0)
 
 - name: firewall | firewall | Add port rules (firewalld)
   ansible.builtin.include_tasks: firewalld.yml
   when: >-
     (openvpn_firewall == 'firewalld')
     or
-    (openvpn_firewall == 'auto' and firewalld.rc == 0 and ufw.rc != 0)
+    (openvpn_firewall == 'auto' and __firewalld.rc == 0 and __ufw.rc != 0)
 
 - name: firewall | firewall | Add port rules (ufw)
   ansible.builtin.include_tasks: ufw.yml
   when: >-
     (openvpn_firewall == 'ufw')
     or
-    (openvpn_firewall == 'auto' and firewalld.rc != 0 and ufw.rc == 0)
+    (openvpn_firewall == 'auto' and __firewalld.rc != 0 and __ufw.rc == 0)

--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -9,7 +9,7 @@
 - name: firewall | firewalld | Enable OpenVPN Port (firewalld)
   ansible.posix.firewalld:
     port: "{{ openvpn_port }}/{{ openvpn_proto }}"
-    zone: "{{ firewalld_default_interface_zone }}"
+    zone: "{{ openvpn_firewalld_default_interface_zone }}"
     permanent: true
     immediate: true
     state: enabled
@@ -25,7 +25,7 @@
 - name: firewall | firewalld | Set default interface to external
   ansible.posix.firewalld:
     interface: "{{ ansible_default_ipv4.interface }}"
-    zone: "{{ firewalld_default_interface_zone }}"
+    zone: "{{ openvpn_firewalld_default_interface_zone }}"
     permanent: true
     immediate: true
     state: enabled
@@ -33,7 +33,7 @@
 - name: firewall | firewalld | Enable masquerading on external zone
   ansible.posix.firewalld:
     masquerade: true
-    zone: "{{ firewalld_default_interface_zone }}"
+    zone: "{{ openvpn_firewalld_default_interface_zone }}"
     permanent: true
     state: enabled
     # Workaround ansible issue: https://github.com/ansible/ansible/pull/21693
@@ -52,5 +52,5 @@
   ansible.builtin.lineinfile:
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ ansible_default_ipv4.interface }}
     regexp: "^ZONE="
-    line: "ZONE={{ firewalld_default_interface_zone }}"
+    line: "ZONE={{ openvpn_firewalld_default_interface_zone }}"
   when: __ifcfg.stat.exists

--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -46,11 +46,11 @@
 - name: firewall | firewalld | Check if ifcfg file exists for {{ ansible_default_ipv4.interface }}
   ansible.builtin.stat:
     path: "/etc/sysconfig/network-scripts/ifcfg-{{ ansible_default_ipv4.interface }}"
-  register: ifcfg
+  register: __ifcfg
 
 - name: firewall | firewalld | Persist default interface in ifcfg file
   ansible.builtin.lineinfile:
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ ansible_default_ipv4.interface }}
     regexp: "^ZONE="
     line: "ZONE={{ firewalld_default_interface_zone }}"
-  when: ifcfg.stat.exists
+  when: __ifcfg.stat.exists

--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -1,7 +1,7 @@
 ---
 - name: firewall | iptables | Change facts to use netfilter-persistent on Debian >= 9 or Ubuntu >= 16
   ansible.builtin.set_fact:
-    iptables_save_command: "/usr/sbin/netfilter-persistent save"
+    __iptables_save_command: "/usr/sbin/netfilter-persistent save"
     openvpn_iptables_service: netfilter-persistent
   when: >-
     (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 9)
@@ -87,7 +87,7 @@
     - Save iptables
 
 - name: firewall | iptables | Save existing iptables rule before start iptables service
-  ansible.builtin.shell: "{{ iptables_save_command }}" # noqa command-instead-of-shell
+  ansible.builtin.shell: "{{ __iptables_save_command }}" # noqa command-instead-of-shell
   when: __iptables_installed.changed is truthy # noqa no-handler
   changed_when: true
 

--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -2,7 +2,7 @@
 - name: firewall | iptables | Change facts to use netfilter-persistent on Debian >= 9 or Ubuntu >= 16
   ansible.builtin.set_fact:
     iptables_save_command: "/usr/sbin/netfilter-persistent save"
-    iptables_service: netfilter-persistent
+    openvpn_iptables_service: netfilter-persistent
   when: >-
     (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 9)
     or
@@ -93,6 +93,6 @@
 
 - name: firewall | iptables | Enable iptables
   ansible.builtin.service:
-    name: "{{ iptables_service }}"
+    name: "{{ openvpn_iptables_service }}"
     enabled: true
     state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,18 +23,18 @@
   ansible.posix.sysctl:
     name: net.ipv4.ip_forward
     value: "1"
-  when: ci_build is falsy
+  when: openvpn_ci_build is falsy
 
 - name: Enable ipv6 forwarding
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
     value: "1"
-  when: openvpn_server_ipv6_network is defined and ci_build is falsy
+  when: openvpn_server_ipv6_network is defined and openvpn_ci_build is falsy
 
 - name: Detect firewall type
   ansible.builtin.import_tasks: firewall/firewall.yml
   when:
-    - ci_build is falsy
+    - openvpn_ci_build is falsy
     - manage_firewall_rules
   tags:
     - firewall

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
   ansible.builtin.import_tasks: firewall/firewall.yml
   when:
     - openvpn_ci_build is falsy
-    - manage_firewall_rules
+    - openvpn_manage_firewall_rules
   tags:
     - firewall
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Generate client configs
   ansible.builtin.import_tasks: client_keys.yml
-  when: clients is defined
+  when: openvpn_clients is defined
   tags:
     - openvpn_generate_clients
 

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,13 +1,13 @@
 ---
 - name: selinux | Check if module was loaded
   ansible.builtin.command: semodule --list-modules
-  register: semodule_loaded
+  register: __semodule_loaded
   changed_when: false
 
 - name: selinux | Setup policy
   when:
     - ansible_selinux.status == 'enabled'
-    - semodule_loaded.stdout.find(openvpn_selinux_module) == -1
+    - __semodule_loaded.stdout.find(openvpn_selinux_module) == -1
   block:
     - name: selinux | Copy selinux type enforcement file
       ansible.builtin.template:

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -139,14 +139,14 @@
 - name: server_keys | Check if certificate revocation list database exists
   ansible.builtin.stat:
     path: "{{ openvpn_key_dir }}/index.txt"
-  register: file_result
+  register: __file_result
 
 - name: server_keys | Create certificate revocation list database if required
   ansible.builtin.file:
     path: "{{ openvpn_key_dir }}/index.txt"
     state: touch
     mode: "0644"
-  when: not file_result.stat.exists
+  when: not __file_result.stat.exists
 
 - name: server_keys | Set up certificate revocation list
   ansible.builtin.command: sh revoke.sh

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -43,12 +43,12 @@ register-dns
 key-direction 1
 {% endif %}
 <ca>
-{{ ca_cert.content|b64decode }}
+{{ __ca_cert.content|b64decode }}
 </ca>
 
 {% if tls_auth_required is truthy %}
 <tls-auth>
-{{ tls_auth.content|b64decode }}
+{{ __tls_auth.content|b64decode }}
 </tls-auth>
 {% endif %}
 

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -39,14 +39,14 @@ route-delay 2
 register-dns
 {% endif %}
 
-{% if tls_auth_required is truthy %}
+{% if openvpn_tls_auth_required is truthy %}
 key-direction 1
 {% endif %}
 <ca>
 {{ __ca_cert.content|b64decode }}
 </ca>
 
-{% if tls_auth_required is truthy %}
+{% if openvpn_tls_auth_required is truthy %}
 <tls-auth>
 {{ __tls_auth.content|b64decode }}
 </tls-auth>

--- a/templates/ldap.conf.j2
+++ b/templates/ldap.conf.j2
@@ -1,26 +1,26 @@
 <LDAP>
     # LDAP server URL
-    URL {{ ldap.url }}
+    URL {{ openvpn_ldap.url }}
 
-{% if not ldap.anonymous_bind %}
+{% if not openvpn_ldap.anonymous_bind %}
     # Bind DN (If your LDAP server doesn't support anonymous binds)
-    BindDN {{ ldap.bind_dn }}
+    BindDN {{ openvpn_ldap.bind_dn }}
     # Bind Password
-    Password {{ ldap.bind_password }}
+    Password {{ openvpn_ldap.bind_password }}
 {% endif %}
 
     # Network timeout (in seconds)
     Timeout 15
 
     # Enable Start TLS
-    TLSEnable {{ ldap.tls_enable }}
+    TLSEnable {{ openvpn_ldap.tls_enable }}
 
     # Follow LDAP Referrals (anonymously)
     FollowReferrals no
 
-{% if ldap.tls_ca_cert_file is defined %}
+{% if openvpn_ldap.tls_ca_cert_file is defined %}
     # TLS CA Certificate File
-    TLSCACertFile {{ ldap.tls_ca_cert_file }}
+    TLSCACertFile {{ openvpn_ldap.tls_ca_cert_file }}
 {% endif %}
 
     # TLS CA Certificate Directory
@@ -28,11 +28,11 @@
 
     # Client Certificate and key
     # If TLS client authentication is required
-{% if ldap.tls_cert_file is defined %}
-    TLSCertFile {{ ldap.tls_cert_file }}
+{% if openvpn_ldap.tls_cert_file is defined %}
+    TLSCertFile {{ openvpn_ldap.tls_cert_file }}
 {% endif %}
-{% if ldap.tls_key_file is defined %}
-    TLSKeyFile {{ ldap.tls_key_file }}
+{% if openvpn_ldap.tls_key_file is defined %}
+    TLSKeyFile {{ openvpn_ldap.tls_key_file }}
 {% endif %}
 
     # Cipher Suite
@@ -42,20 +42,20 @@
 
 <Authorization>
     # Base DN
-    BaseDN "{{ ldap.base_dn }}"
+    BaseDN "{{ openvpn_ldap.base_dn }}"
 
     # User Search Filter
-    SearchFilter "{{ ldap.search_filter }}"
+    SearchFilter "{{ openvpn_ldap.search_filter }}"
 
-{% if ldap.require_group %}
+{% if openvpn_ldap.require_group %}
     # Require Group Membership
     RequireGroup True
     # Add non-group members to a PF table (disabled)
     #PFTable ips_vpn_users
 
     <Group>
-        BaseDN "{{ ldap.group_base_dn }}"
-        SearchFilter "{{ ldap.group_search_filter }}"
+        BaseDN "{{ openvpn_ldap.group_base_dn }}"
+        SearchFilter "{{ openvpn_ldap.group_search_filter }}"
         MemberAttribute uniqueMember
         # Add group members to a PF table (disabled)
         #PFTable ips_vpn_eng

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -21,7 +21,7 @@ crl-verify {{ openvpn_crl_path }}
 {% if openvpn_use_crl is truthy %}
 crl-verify {{ openvpn_key_dir }}/ca-crl.pem
 {% endif %}
-{% if tls_auth_required %}
+{% if openvpn_tls_auth_required %}
 tls-auth {{ openvpn_key_dir }}/ta.key 0
 {% endif %}
 tls-server

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -119,8 +119,8 @@ plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so "{{ openvpn_base_dir }
 {% else %}
 plugin /usr/lib/openvpn/plugin/lib/openvpn-auth-ldap.so "{{ openvpn_base_dir }}/auth/ldap.conf"
 {% endif %}
-{% if ldap.verify_client_cert is defined %}
-verify-client-cert {{ ldap.verify_client_cert }}
+{% if openvpn_ldap.verify_client_cert is defined %}
+verify-client-cert {{ openvpn_ldap.verify_client_cert }}
 {% else %}
 client-cert-not-required
 {% endif %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,7 +3,7 @@
   hosts: 127.0.0.1
   connection: local
   vars:
-    ci_build: true
+    openvpn_ci_build: true
     openvpn_client_register_dns: false
     openvpn_use_pregenerated_dh_params: true
   roles:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,6 +8,6 @@
     openvpn_use_pregenerated_dh_params: true
   roles:
     - role: ansible-role-openvpn
-      clients:
+      openvpn_clients:
         - alpha
         - omega

--- a/vars/os/Debian.yml
+++ b/vars/os/Debian.yml
@@ -1,2 +1,2 @@
 ---
-iptables_save_command: "/etc/init.d/iptables-persistent save"
+__iptables_save_command: "/etc/init.d/iptables-persistent save"

--- a/vars/os/FreeBSD.yml
+++ b/vars/os/FreeBSD.yml
@@ -1,5 +1,5 @@
 ---
-manage_firewall_rules: false
+openvpn_manage_firewall_rules: false
 openvpn_config_file: "openvpn"
 openvpn_base_dir: /usr/local/etc/openvpn
 openvpn_key_dir: /usr/local/etc/openvpn/keys

--- a/vars/os/RedHat.yml
+++ b/vars/os/RedHat.yml
@@ -1,2 +1,2 @@
 ---
-iptables_save_command: "iptables-save > /etc/sysconfig/iptables"
+__iptables_save_command: "iptables-save > /etc/sysconfig/iptables"


### PR DESCRIPTION
And fix current violations by renaming or adding to the pattern.