### PR TITLE
Rework firewalld configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ In part because of [Requiring OpenVPN 2.5](#requiring-openvpn-25), some variable
 * `openvpn_tls_auth_required` has been replaced with `openvpn_use_tls_crypt`. The default for `openvpn_tls_auth_required` is now `false`.
   * Restore the old behaviour with `openvpn_tls_auth_required: true`
 
+* Functionality needing the `openvpn_firewalld_default_interface_zone` has been replaced by using the zone from the interface with the default route. The `openvpn_firewalld_default_interface_zone` variable has been removed.
+  * It is not possible to restore the old behaviour
+
 Variables are prefixed with `openvpn_` to make sure they are isolated to this role. (There are [limited exceptions](.ansible-lint.yml)) You will need to update any variable you have overriden.
 
 Configurable variable renames include:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Change these options if you need to force a particular firewall or change how th
 
 | Variable                         | Type    | Choices                        | Default  | Comment                                                                                                     |
 |----------------------------------|---------|--------------------------------|----------|-------------------------------------------------------------------------------------------------------------|
-| openvpn_firewalld_default_interface_zone | string  |                                | public   | Firewalld zone where the "ansible_default_ipv4.interface" will be pushed into                               |
 | openvpn_iptables_service                 | string  |                                | iptables | Override the iptables service name                                                                          |
 | openvpn_manage_firewall_rules            | boolean | true, false                    | true     | Allow playbook to manage iptables                                                                           |
 | openvpn_firewall                 | string  | auto, firewalld, ufw, iptables | auto     | The firewall software to configure network rules. "auto" will attempt to detect it by inspecting the system |

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -16,7 +16,6 @@ openvpn_fetch_client_configs_dir: /tmp/ansible
 openvpn_fetch_client_configs_suffix: ""
 
 # Firewall
-openvpn_firewalld_default_interface_zone: public
 openvpn_iptables_service: iptables
 openvpn_manage_firewall_rules: true
 openvpn_firewall: auto

--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -34,7 +34,7 @@
     immediate: true
     state: enabled
 
-- name: firewall | firewalld | Enable masquerading on external zone
+- name: firewall | firewalld | Enable masquerading on default interface's zone
   ansible.posix.firewalld:
     masquerade: true
     zone: "{{ __firewalld_default_zone.stdout }}"

--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -6,26 +6,30 @@
     masked: false
     state: started
 
+# Default interface is the one that routes the traffic
+# Assume that's what we want for a server
+# https://medium.com/opsops/ansible-default-ipv4-is-not-what-you-think-edb8ab154b10
+- name: firewall | firewalld | Get zone of default interface
+  ansible.builtin.command: firewall-cmd --get-zone-of-interface={{ ansible_default_ipv4.interface }}
+  register: __firewalld_default_zone
+  check_mode: false
+  changed_when: false # Read only, never report as changed
+  failed_when: false
+
 - name: firewall | firewalld | Enable OpenVPN Port (firewalld)
   ansible.posix.firewalld:
     port: "{{ openvpn_port }}/{{ openvpn_proto }}"
-    zone: "{{ openvpn_firewalld_default_interface_zone }}"
+    zone: "{{ __firewalld_default_zone.stdout }}"
     permanent: true
     immediate: true
     state: enabled
 
-- name: firewall | firewalld | Set tun0 interface to internal
+- name: firewall | firewalld | Set tun0 interface to trusted
+  # We need the tun0 interface to be trusted so that packets from other systems
+  # can be routed through the VPN tunnel.
   ansible.posix.firewalld:
     interface: tun0
-    zone: internal
-    permanent: true
-    immediate: true
-    state: enabled
-
-- name: firewall | firewalld | Set default interface to external
-  ansible.posix.firewalld:
-    interface: "{{ ansible_default_ipv4.interface }}"
-    zone: "{{ openvpn_firewalld_default_interface_zone }}"
+    zone: trusted
     permanent: true
     immediate: true
     state: enabled
@@ -33,24 +37,9 @@
 - name: firewall | firewalld | Enable masquerading on external zone
   ansible.posix.firewalld:
     masquerade: true
-    zone: "{{ openvpn_firewalld_default_interface_zone }}"
+    zone: "{{ __firewalld_default_zone.stdout }}"
     permanent: true
     state: enabled
-    # Workaround ansible issue: https://github.com/ansible/ansible/pull/21693
-    # immediate: true
+    immediate: true
   notify:
     - Restart firewalld
-
-# workaround for --permanent not working on non-NetworkManager managed ifaces
-# https://bugzilla.redhat.com/show_bug.cgi?id=1112742
-- name: firewall | firewalld | Check if ifcfg file exists for {{ ansible_default_ipv4.interface }}
-  ansible.builtin.stat:
-    path: "/etc/sysconfig/network-scripts/ifcfg-{{ ansible_default_ipv4.interface }}"
-  register: __ifcfg
-
-- name: firewall | firewalld | Persist default interface in ifcfg file
-  ansible.builtin.lineinfile:
-    dest: /etc/sysconfig/network-scripts/ifcfg-{{ ansible_default_ipv4.interface }}
-    regexp: "^ZONE="
-    line: "ZONE={{ openvpn_firewalld_default_interface_zone }}"
-  when: __ifcfg.stat.exists


### PR DESCRIPTION
Discovered that we need to have the VPN tunner adaptor in the trusted group to allow the default allow policy to take effect.

Also decided to stop messing with the interface zones and just add the openvpn port to the active zone on the interface with the default route.