### PR TITLE
Remove -days from certificate request generation & use argv to break up long command lines

### DIFF
--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -14,10 +14,19 @@
     mode: "0400"
 
 - name: client_keys | Generate client key
-  ansible.builtin.command: >-
-    openssl req -nodes -newkey rsa:{{ openvpn_rsa_bits }} -keyout {{ item }}.key -out {{ item }}.csr
-    -days 3650 -subj /CN=OpenVPN-Client-{{ inventory_hostname[:24] }}-{{ item[:24] }}/
-  args:
+  ansible.builtin.command:
+    argv:
+      - openssl
+      - req
+      - -nodes
+      - -newkey
+      - rsa:{{ openvpn_rsa_bits }}
+      - -keyout
+      - "{{ item }}.key"
+      - -out
+      - "{{ item }}.csr"
+      - -subj
+      - /CN=OpenVPN-Client-{{ inventory_hostname[:24] }}-{{ item[:24] }}/
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ item }}.key"
   with_items:

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -31,10 +31,19 @@
   when: openvpn_ca_key is defined
 
 - name: server_keys | Generate CA key
-  ansible.builtin.command: >-
-    openssl req -nodes -newkey rsa:{{ openvpn_rsa_bits }} -keyout ca-key.pem -out ca-csr.pem
-    -days 3650 -subj /CN=OpenVPN-CA-{{ inventory_hostname[:53] }}/
-  args:
+  ansible.builtin.command:
+    argv:
+      - openssl
+      - req
+      - -nodes
+      - -newkey
+      - rsa:{{ openvpn_rsa_bits }}
+      - -keyout
+      - ca-key.pem
+      - -out
+      - ca-csr.pem
+      - -subj
+      - /CN=OpenVPN-CA-{{ inventory_hostname[:53] }}/
     chdir: "{{ openvpn_key_dir }}"
     creates: ca-key.pem
   when: openvpn_ca_key is not defined
@@ -53,9 +62,19 @@
   when: openvpn_ca_key is not defined
 
 - name: server_keys | Generate server key
-  ansible.builtin.command: >-
-    openssl req -nodes -newkey rsa:{{ openvpn_rsa_bits }} -keyout server.key -out server.csr
-    -days 3650 -subj /CN=OpenVPN-Server-{{ inventory_hostname[:49] }}/
+  ansible.builtin.command:
+    argv:
+      - openssl
+      - req
+      - -nodes
+      - -newkey
+      - rsa:{{ openvpn_rsa_bits }}
+      - -keyout
+      - server.key
+      - -out
+      - server.csr
+      - -subj
+      - /CN=OpenVPN-Server-{{ inventory_hostname[:49] }}/
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: server.key
@@ -66,11 +85,25 @@
     mode: "0400"
 
 - name: server_keys | Sign server key
-  ansible.builtin.command: >
-    openssl x509 -req -in server.csr -out server.crt
-    -CA ca.crt -CAkey ca-key.pem -sha256 -days 3650
-    -CAcreateserial -extfile openssl-server.ext
-  args:
+  ansible.builtin.command:
+    argv:
+      - openssl
+      - x509
+      - -req
+      - -in
+      - server.csr
+      - -out
+      - server.crt
+      - -CA
+      - ca.crt
+      - -CAkey
+      - ca-key.pem
+      - -sha256
+      - -days
+      - 3650
+      - -CAcreateserial
+      - -extfile
+      - openssl-server.ext
     chdir: "{{ openvpn_key_dir }}"
     creates: server.crt
 


### PR DESCRIPTION
Request generation has output like
```
TASK [ansible-role-openvpn : server_keys | Generate CA key] ********************
task path: /etc/ansible/roles/ansible-role-openvpn/tasks/server_keys.yml:33
changed: [localhost] => {"changed": true, 
"cmd": ["openssl", "req", "-nodes", "-newkey", "rsa:2048", "-keyout", "ca-key.pem", "-out", "ca-csr.pem", "-days", "3650", "-subj", "/CN=OpenVPN-CA-localhost/"], 
"delta": "0:00:00.040497", 
"end": "2024-12-29 00:48:45.248738", 
"msg": "", 
"rc": 0, 
"start": "2024-12-29 00:48:45.208241", 
"stderr": "Ignoring -days without -x509; not generating a certificate\n
...
```

Similar problem also showed up in https://github.com/wazuh/wazuh-packages/issues/2661, they reference [req](https://linux.die.net/man/1/req) which does say `-days` is used with `-x509`.

Drop the `-days` from the key creation.

And move the long lines to use the `argv` parameter in the ansible command plugin.