### PR TITLE
Fix messages & tagging, and improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ In part because of [Requiring OpenVPN 2.5](#requiring-openvpn-25), some variable
 
 * `openvpn_redirect_gateway` is now the string `def1 bypass-dhcp ipv6` instead of a boolean
   * Restore the old behaviour with `openvpn_redirect_gateway: "def1 bypass-dhcp"`
-  * Disable it by setting it to ''
+  * Disable it by setting it to an empty string `''` (Added in 3.0.2)
 
 * Setting both `openvpn_crl_path` and `openvpn_use_crl` resulted in duplicate `crl-verify` directives. This has been resolved in favour of removing `openvpn_crl_path` for consistency since the other certificate paths can't be set.
   * It is not possible to restore the old behaviour

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ These options change how OpenVPN itself works. Refer to the respective OpenVPN R
 | openvpn_local               | string       |                   | `unset`                    | Local host name or IP address for bind.  If specified, OpenVPN will bind to this address only.  If unspecified, OpenVPN will bind to all interfaces. |
 | openvpn_port                | int          |                   | 1194                       | The port you want OpenVPN to run on. If you have different ports on different servers, I suggest you set the port in your inventory file.            |
 | openvpn_proto               | string       | udp, tcp          | udp                        | The protocol you want OpenVPN to use  |
-| openvpn_redirect_gateway    | string      |       | `def1 bypass-dhcp ipv6` | Flag values |
+| openvpn_redirect_gateway    | string      |       | `def1 bypass-dhcp ipv6` | Sets the `redirect-gateway` value that gets pushed to clients. Set to an empty string to disable sending it |
 | openvpn_resolv_retry        | int/string   | any int, infinite | 5                          | Hostname resolv failure retry seconds. Set "infinite" to retry indefinitely in case of poor connection or laptop sleep mode recovery etc.            |
 | openvpn_server_hostname     | string       |                   | `{{ inventory_hostname }}` | The server name to place in the client configuration file                                                                                            |
 | openvpn_server_ipv6_network | string       |                   | `fdbf:dd0d:1a49:2091::/64` | The network address and prefix of an IPv6 network to assign to clients. |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,4 +70,4 @@
 - name: Configure OpenVPN server
   ansible.builtin.import_tasks: config.yml
   tags:
-  - config
+    - config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,3 +69,5 @@
 
 - name: Configure OpenVPN server
   ansible.builtin.import_tasks: config.yml
+  tags:
+  - config

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,7 @@
 - name: Run CI tests
   hosts: 127.0.0.1
   connection: local
+  become: true
   vars:
     openvpn_ci_build: true
     openvpn_client_register_dns: false


### PR DESCRIPTION
* Wanted to extend docs after #236 
* Added a tag `config` to just run the config setup
* Add `become: true` to test playbook so I can run the playbook on codespaces without complaints about lacking permissions