### PR TITLE
Check if openvpn_server_ipv6_network is defined and not empty to fix old behaviour

### DIFF
--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -76,7 +76,7 @@
         action: insert
         comment: "Perform NAT IPv6 readdressing"
         ip_version: ipv6
-      when: openvpn_server_ipv6_network is defined
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
 
 - name: firewall | iptables | Perform NAT readdressing with MASQUERADE
   when: openvpn_masquerade_not_snat is truthy and openvpn_no_nat is falsy

--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -101,7 +101,7 @@
         action: insert
         comment: "Perform NAT IPv6 readdressing"
         ip_version: ipv6
-      when: openvpn_server_ipv6_network is defined
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
 
 - name: firewall | iptables | Save existing iptables rule before start iptables service
   ansible.builtin.shell: "{{ __iptables_save_command }}" # noqa command-instead-of-shell

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -43,7 +43,7 @@ client-to-client
 {% endif %}
 
 server {{ openvpn_server_network }} {{ openvpn_server_netmask }}
-{% if openvpn_server_ipv6_network is defined %}
+{% if openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network %}
 server-ipv6 {{ openvpn_server_ipv6_network }}
 {% endif %}
 {% if openvpn_topology is defined %}


### PR DESCRIPTION
When there's no ipv6 available on my EC2 instance and I want to disable it by setting `openvpn_server_ipv6_network` to `null` (as I found here https://github.com/kyl191/ansible-role-openvpn/pull/217/files) the check fails: 

```
TASK [kyl191.openvpn : firewall | iptables | Perform NAT IPv6 readdressing] ***************************************************************************************************************************************************************
fatal: [vpn.awesomecompany.com]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'address'. 'dict object' has no attribute 'address'\n\nThe error appears to be in '/Users/xxxx/projects/docker/xxx/ansible-bastion/roles/kyl191.openvpn/tasks/firewall/iptables.yml': line 68, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n        comment: \"Perform NAT readdressing\"\n    - name: firewall | iptables | Perform NAT IPv6 readdressing\n      ^ here\n"}
```

Because when you define it to `null` it is still defined.

This is fixed by this pull request by also checking if there's value.