### PR TITLE
Fix when no ipv6

### DIFF
--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -51,6 +51,6 @@
     permanent: true
     state: enabled
     immediate: true
-  when: openvpn_server_ipv6_network is defined
+  when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
   notify:
     - Restart firewalld

--- a/tasks/firewall/ufw.yml
+++ b/tasks/firewall/ufw.yml
@@ -58,7 +58,7 @@
           :POSTROUTING ACCEPT [0:0]
           -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }} -j SNAT --to-source {{ ansible_default_ipv6.address }}
           COMMIT
-      when: openvpn_server_ipv6_network is defined
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
 
 - name: firewall | ufw | Setup NAT with MASQUERADE
   when: openvpn_masquerade_not_snat is truthy and openvpn_no_nat is falsy
@@ -87,4 +87,4 @@
           :POSTROUTING ACCEPT [0:0]
           -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }}  -j MASQUERADE
           COMMIT
-      when: openvpn_server_ipv6_network is defined
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
     value: "1"
-  when: openvpn_server_ipv6_network is defined and openvpn_ci_build is falsy
+  when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network and openvpn_ci_build is falsy
 
 - name: Detect firewall type
   ansible.builtin.import_tasks: firewall/firewall.yml


### PR DESCRIPTION
If IPv6 is disabled on my system the playbook run fails with:

```
TASK [kyl191.openvpn : firewall | ufw | Setup IPv6 SNAT rules] *********************************************************************************************************************************************************************************************
fatal: [x.x.x.x]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'dict object' has no attribute 'address'\n\nThe error appears to be in '/home/xxxxx/.ansible/roles/kyl191.openvpn/tasks/firewall/ufw.yml': line 50, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: firewall | ufw | Setup IPv6 SNAT rules\n      ^ here\n"}
```

I followed the suggested workaround to set `openvpn_server_ipv6_network: null`, but it is still not enough as the variable is defined.

The only solution is to modify the when states.

Thanks for merging