### PR TITLE
Try fixing #247

### DIFF
--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -51,6 +51,6 @@
     permanent: true
     state: enabled
     immediate: true
-  when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
+  when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
   notify:
     - Restart firewalld

--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -76,7 +76,7 @@
         action: insert
         comment: "Perform NAT IPv6 readdressing"
         ip_version: ipv6
-      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
 
 - name: firewall | iptables | Perform NAT readdressing with MASQUERADE
   when: openvpn_masquerade_not_snat is truthy and openvpn_no_nat is falsy
@@ -101,7 +101,7 @@
         action: insert
         comment: "Perform NAT IPv6 readdressing"
         ip_version: ipv6
-      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
 
 - name: firewall | iptables | Save existing iptables rule before start iptables service
   ansible.builtin.shell: "{{ __iptables_save_command }}" # noqa command-instead-of-shell

--- a/tasks/firewall/ufw.yml
+++ b/tasks/firewall/ufw.yml
@@ -58,7 +58,7 @@
           :POSTROUTING ACCEPT [0:0]
           -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }} -j SNAT --to-source {{ ansible_default_ipv6.address }}
           COMMIT
-      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
 
 - name: firewall | ufw | Setup NAT with MASQUERADE
   when: openvpn_masquerade_not_snat is truthy and openvpn_no_nat is falsy
@@ -87,4 +87,4 @@
           :POSTROUTING ACCEPT [0:0]
           -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }}  -j MASQUERADE
           COMMIT
-      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network
+      when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0


### PR DESCRIPTION
Update to Ansible 13 and my local test matches the report.

```
TASK [kyl191.openvpn : firewall | firewalld | Enable masquerading on ipv6] *********************************************************************************************
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'str' at '/home/admin/ansible-playbooks/roles/kyl191.openvpn/defaults/main/openvpn.yml:26
:30'. Conditionals must have a boolean result.                                                                                                                          
                                                                                                                                                                        
Task failed.                                                                                                                                                            
Origin: /home/admin/ansible-playbooks/roles/kyl191.openvpn/tasks/firewall/firewalld.yml:47:3                                                                            
                                                                                                                                                                        
45     - Restart firewalld                                                                                                                                              
46                                                                                                                                                                      
47 - name: firewall | firewalld | Enable masquerading on ipv6                                                                                                           
     ^ column 3                                                                     
                                                                                                                                                                        
<<< caused by >>>                                                                                                                                                       
                                                                                                                                                                        
Conditional result (True) was derived from value of type 'str' at '/home/admin/ansible-playbooks/roles/kyl191.openvpn/defaults/main/openvpn.yml:26:30'. Conditionals mus
t have a boolean result.                                                                                                                                                
Origin: /home/admin/ansible-playbooks/roles/kyl191.openvpn/tasks/firewall/firewalld.yml:54:9                                                                            
                                                                                                                                                                        
52     state: enabled                                                                                                                                                   
53     immediate: true                                                                                                                                                  54   when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network                                                                                       
           ^ column 9                                                                                                                                                   
                                                                                                                                                                        
Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
```

After adding `| length > 0` the failure went away.

Add the check for the other firewalls as well.