### PR TITLE
Address fact lint issues

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
     name: "{{ openvpn_service_name }}"
     state: restarted
   # Github Actions doesn't allow entrypoints, so PID 1 isn't an init system
-  when: ansible_service_mgr != "tail"
+  when: ansible_facts['service_mgr'] != "tail"
 
 - name: Restart iptables
   ansible.builtin.service:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -116,7 +116,7 @@
   when: openvpn_client_config is falsy
 
 - name: config | Create openvpn service override
-  when: ansible_service_mgr == "systemd"
+  when: ansible_facts['service_mgr'] == "systemd"
   block:
     - name: config | Create openvpn service override directory
       ansible.builtin.file:
@@ -137,4 +137,4 @@
     enabled: true
     state: started
   # Github Actions doesn't allow entrypoints, so PID 1 isn't an init system
-  when: ansible_service_mgr != "tail"
+  when: ansible_facts['service_mgr'] != "tail"

--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -10,7 +10,7 @@
 # Assume that's what we want for a server
 # https://medium.com/opsops/ansible-default-ipv4-is-not-what-you-think-edb8ab154b10
 - name: firewall | firewalld | Get zone of default interface
-  ansible.builtin.command: firewall-cmd --get-zone-of-interface={{ ansible_default_ipv4.interface }}
+  ansible.builtin.command: firewall-cmd --get-zone-of-interface={{ ansible_facts['default_ipv4']['interface'] }}
   register: __firewalld_default_zone
   check_mode: false
   changed_when: false # Read only, never report as changed

--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -4,23 +4,23 @@
     __iptables_save_command: "/usr/sbin/netfilter-persistent save"
     openvpn_iptables_service: netfilter-persistent
   when: >-
-    (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 9)
+    (ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_version']|int >= 9)
     or
-    (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
+    (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['lsb']['major_release']|int >= 16)
 
 - name: firewall | iptables | Install iptables-persistent (Debian/Ubuntu)
   ansible.builtin.package:
     name: "{{ iptables_persistent_package_name }}"
     state: present
   register: __iptables_installed
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: firewall | iptables | Install iptables-services (RedHat/CentOS)
   ansible.builtin.package:
     name: "{{ iptables_services_package_name }}"
     state: present
   register: __iptables_installed
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: firewall | iptables | Allow forwarding from tun devices
   ansible.builtin.iptables:
@@ -61,7 +61,7 @@
         chain: POSTROUTING
         source: "{{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
         destination: "! {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
-        to_source: "{{ ansible_default_ipv4.address }}"
+        to_source: "{{ ansible_facts['default_ipv4']['address'] }}"
         jump: SNAT
         action: insert
         comment: "Perform NAT readdressing"
@@ -71,7 +71,7 @@
         chain: POSTROUTING
         source: "{{ openvpn_server_ipv6_network }}"
         destination: "! {{ openvpn_server_ipv6_network }}"
-        to_source: "{{ ansible_default_ipv6.address }}"
+        to_source: "{{ ansible_facts['default_ipv6']['address'] }}"
         jump: SNAT
         action: insert
         comment: "Perform NAT IPv6 readdressing"

--- a/tasks/firewall/ufw.yml
+++ b/tasks/firewall/ufw.yml
@@ -56,7 +56,7 @@
           # OpenVPN config
           *nat
           :POSTROUTING ACCEPT [0:0]
-          -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }} -j SNAT --to-source {{ ansible_default_ipv6.address }}
+          -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }} -j SNAT --to-source {{ ansible_facts['default_ipv6']['address'] }}
           COMMIT
       when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,20 +11,20 @@
   ansible.builtin.package:
     name: "{{ epel_package_name }}"
     state: present
-  when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora" and ansible_distribution !="RedHat"
+  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution'] != "Fedora" and ansible_facts['distribution'] !="RedHat"
 
 # EPEL install is different for RHEL specifically: https://www.redhat.com/en/blog/install-epel-linux
 - name: install | Install EPEL for RHEL
   ansible.builtin.dnf:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
     state: present
     disable_gpg_check: true
-  when: ansible_distribution == "RedHat"
+  when: ansible_facts['distribution'] == "RedHat"
 
 - name: install | Refresh apt cache
   ansible.builtin.apt:
     update_cache: true
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: install | Install openvpn
   ansible.builtin.package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Include vars for OpenVPN installation
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-    - "../vars/os/{{ ansible_distribution }}{{ ansible_distribution_major_version }}.yml"
-    - "../vars/os/{{ ansible_distribution }}.yml"
-    - "../vars/os/{{ ansible_os_family }}.yml"
+    - "../vars/os/{{ ansible_facts['distribution'] }}{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "../vars/os/{{ ansible_facts['distribution'] }}.yml"
+    - "../vars/os/{{ ansible_facts['os_family'] }}.yml"
     - "../vars/empty.yml"
 
 - name: Uninstall OpenVPN
@@ -42,7 +42,7 @@
 - name: Configure SELinux
   ansible.builtin.import_tasks: selinux.yml
   when:
-    - ansible_selinux.status == "enabled"
+    - ansible_facts['selinux']['status'] == "enabled"
 
 - name: Compare existing certs against 'clients' variable
   ansible.builtin.import_tasks: cert_sync_detection.yml

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -6,7 +6,7 @@
 
 - name: selinux | Setup policy
   when:
-    - ansible_selinux.status == 'enabled'
+    - ansible_facts['selinux']['status'] == 'enabled'
     - __semodule_loaded.stdout.find(openvpn_selinux_module) == -1
   block:
     - name: selinux | Copy selinux type enforcement file

--- a/tasks/server_keys_crl.yml
+++ b/tasks/server_keys_crl.yml
@@ -60,7 +60,7 @@
     enabled: true
     state: started
     daemon_reload: true
-  when: ansible_service_mgr == "systemd"
+  when: ansible_facts['service_mgr'] == "systemd"
 
 - name: server_keys_crl | Fail if there's no systemd
   ansible.builtin.fail:
@@ -69,5 +69,5 @@
       "This is unsupported - You must setup an alternate method to renew the CRL manually. "
       "Set the variable openvpn_manage_crl_without_systemd to true to disable this check."
   when:
-    - ansible_service_mgr != "systemd"
+    - ansible_facts['service_mgr'] != "systemd"
     - openvpn_manage_crl_without_systemd is falsy

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -109,10 +109,10 @@ management-client-user {{ openvpn_management_client_user }}
 
 {% if openvpn_use_ldap is truthy %}
 ### LDAP AUTH ###
-{% if ansible_os_family == 'Debian' %}
+{% if ansible_facts['os_family'] == 'Debian' %}
 plugin /usr/lib/openvpn/openvpn-auth-ldap.so "{{ openvpn_base_dir }}/auth/ldap.conf"
-{% elif ansible_machine == "x86_64" %}
-{% if ansible_distribution in ['RedHat','Rocky'] and (ansible_distribution_major_version | int >= 8) %}
+{% elif ansible_facts['machine'] == "x86_64" %}
+{% if ansible_facts['distribution'] in ['RedHat','Rocky'] and (ansible_facts['distribution_major_version']|int >= 8) %}
 plugin /usr/lib64/openvpn/plugins/openvpn-auth-ldap.so "{{ openvpn_base_dir }}/auth/ldap.conf"
 {% else %}
 plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so "{{ openvpn_base_dir }}/auth/ldap.conf"


### PR DESCRIPTION
Whole lot of lint issues on the new Ansible 13: https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_13.html#inject-facts-as-vars

```
RUNNING HANDLER [kyl191.openvpn : Restart openvpn] *********************************************************************************************************************
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed fr
om ansible-core version 2.24.                                                                                                                                           
Origin: /home/admin/ansible-playbooks/roles/kyl191.openvpn/handlers/main.yml:7:9                                                                                        
                                                                                                                                                                        
5     state: restarted                                                                                                                                                  
6   # Github Actions doesn't allow entrypoints, so PID 1 isn't an init system                                                                                           
7   when: ansible_service_mgr != "tail"                                                                                                                                 
          ^ column 9                                                                                                                                                    
                                                                                                                                                                        
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```