### PR TITLE
Add flexible client config file naming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These options change how the role works. This is a catch-all group, specific gro
 | openvpn_client_config_no_log | boolean | true, false | true              | Prevent client configuration files to be logged to stdout by Ansible          |
 | openvpn_key_dir              | string  |             | /etc/openvpn/keys | Path where your server private keys and CA will be stored                     |
 | openvpn_ovpn_dir             | string  |             | /etc/openvpn      | Path where your client configurations will be stored                          |
+| openvpn_ovpn_server_name     | string  |             | `{{ inventory_hostname }}` | Server name used in generated client `.ovpn` file names (`clientname-<openvpn_ovpn_server_name>.ovpn`) |
 | openvpn_revoke_these_certs   | list    |             | []                | List of client certificates to revoke (requires `openvpn_use_crl` to be true). |
 | openvpn_selinux_module       | string  |             | my-openvpn-server | Set the SELinux module name                                                   |
 | openvpn_selinux_use_semanage | boolean | true, false | true              | Use `semanage` to configure SELinux ports instead of compiling a custom module. |
@@ -70,11 +71,12 @@ These options change how the role works. This is a catch-all group, specific gro
 
 Change these options if you need to adjust how the configs are download to your local system
 
-| Variable                            | Type    | Choices     | Default      | Comment                                                                                                                                   |
-|-------------------------------------|---------|-------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| openvpn_fetch_client_configs        | boolean | true, false | true         | Download generated client configurations to the local system                                                                              |
-| openvpn_fetch_client_configs_dir    | string  |             | /tmp/ansible | If openvpn_fetch_client_configs is true, the local directory to download the client config files into                                     |
-| openvpn_fetch_client_configs_suffix | string  |             | ""           | If openvpn_fetch_client_configs is true, the suffix to append to the downloaded client config files before the trailing `.ovpn` extension |
+| Variable                                  | Type    | Choices     | Default      | Comment                                                                                                                                   |
+|-------------------------------------------|---------|-------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| openvpn_fetch_client_configs              | boolean | true, false | true         | Download generated client configurations to the local system                                                                              |
+| openvpn_fetch_client_configs_dir          | string  |             | /tmp/ansible | If openvpn_fetch_client_configs is true, the local directory to download the client config files into                                     |
+| openvpn_fetch_client_configs_suffix       | string  |             | ""           | If openvpn_fetch_client_configs is true, the suffix to append to the downloaded client config files before the trailing `.ovpn` extension |
+| openvpn_fetch_client_configs_per_user_dir | boolean | true, false | true         | If true, each client config is downloaded into a per-user subdirectory: `<openvpn_fetch_client_configs_dir>/<user>/<openvpn_ovpn_server_name>.ovpn`. If false, all configs go into a single flat directory: `<openvpn_fetch_client_configs_dir>/<user>-<openvpn_ovpn_server_name>.ovpn` |
 
 ### Firewall
 

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -9,11 +9,14 @@ openvpn_clients: []
 openvpn_base_dir: "/etc/openvpn/server"
 openvpn_key_dir: "{{ openvpn_base_dir }}/keys"
 openvpn_ovpn_dir: "{{ openvpn_base_dir }}"
+# Server name to use in client configuration file name
+openvpn_ovpn_server_name: "{{ inventory_hostname }}"
 
 # Config fetch settings
 openvpn_fetch_client_configs: true
 openvpn_fetch_client_configs_dir: /tmp/ansible
 openvpn_fetch_client_configs_suffix: ""
+openvpn_fetch_client_configs_per_user_dir: true
 
 # Firewall
 openvpn_iptables_service: iptables

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -82,7 +82,7 @@
   no_log: "{{ openvpn_client_config_no_log }}"
   ansible.builtin.template:
     src: client.ovpn.j2
-    dest: "{{ openvpn_ovpn_dir }}/{{ item.0.item }}-{{ inventory_hostname }}.ovpn"
+    dest: "{{ openvpn_ovpn_dir }}/{{ item.0.item }}-{{ openvpn_ovpn_server_name }}.ovpn"
     owner: "{{ openvpn_conf_user }}"
     group: "{{ openvpn_conf_group }}"
     mode: "0400"
@@ -92,9 +92,11 @@
 
 - name: client_keys | Fetch client config
   ansible.builtin.fetch:
-    src: "{{ openvpn_ovpn_dir }}/{{ item }}-{{ inventory_hostname }}.ovpn"
-    dest: "{{ openvpn_fetch_client_configs_dir }}/{{ item }}/{{ inventory_hostname }}{{ openvpn_fetch_client_configs_suffix }}.ovpn"
+    src: "{{ openvpn_ovpn_dir }}/{{ item }}-{{ openvpn_ovpn_server_name }}.ovpn"
+    dest: "{{ openvpn_fetch_client_configs_dir }}/{{ item }}{{ __path_separator }}{{ openvpn_ovpn_server_name }}{{ openvpn_fetch_client_configs_suffix }}.ovpn"
     flat: true
+  vars:
+    __path_separator: "{{ '/' if openvpn_fetch_client_configs_per_user_dir else '-' }}"
   when: openvpn_fetch_client_configs is truthy
   with_items:
     - "{{ openvpn_clients }}"

--- a/tasks/revocation.yml
+++ b/tasks/revocation.yml
@@ -1,7 +1,7 @@
 ---
 - name: revocation | Remove client config
   ansible.builtin.file:
-    path: "{{ openvpn_ovpn_dir }}/{{ item }}-{{ inventory_hostname }}.ovpn"
+    path: "{{ openvpn_ovpn_dir }}/{{ item }}-{{ openvpn_ovpn_server_name }}.ovpn"
     state: absent
     force: true
   with_items:


### PR DESCRIPTION
## Add flexible client config file naming options

### What

Two new variables to replace the hard-coded `inventory_hostname` in client `.ovpn` file names and fetch paths:

**`openvpn_ovpn_server_name`** (default: `{{ inventory_hostname }}`)

Replaces the hard-coded `inventory_hostname` in `.ovpn` file names on the server side and when fetching to the control node. The revocation task is also updated.

**`openvpn_fetch_client_configs_per_user_dir`** (default: `true`)

Controls the layout of fetched config files on the control node:

- `true` (default) - per-user subdirectory: `<dir>/<user>/<server>.ovpn`
- `false` - flat layout: `<dir>/<user>-<server>.ovpn`

Both variables default to the previous behavior, so no changes are required for existing deployments.

### Why

Hardcoding `inventory_hostname` in file names is limiting. The OpenVPN server name may simply differ from the inventory hostname, or it may be more convenient to use a short label rather than a full FQDN.

Similarly, storing all fetched configs in a single flat directory rather than creating a subdirectory per user can be more practical, especially in single-server setups.

Having the option to configure these things is better than not having it.

### Why `openvpn_ovpn_server_name` and not `openvpn_server_hostname`?

`openvpn_server_hostname` already exists and sets the `remote` directive inside the client config - the address clients use to connect. Reusing it for file naming would couple network addressing to file system layout, which often need to be different values (e.g. FQDN for the connection vs. a short label for the file name). A dedicated variable also preserves backward compatibility for existing installations that already set `openvpn_server_hostname`.