### PR TITLE
Add configurable certificate CN variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,21 @@ These options change how OpenVPN itself works. Refer to the respective OpenVPN R
 
 #### Certificate Common Names (CN)
 
-X.509 limits the CN field to **64 characters**. The default values for the variables below truncate `inventory_hostname` so that the built-in prefix and the hostname together stay within this limit. If you supply a custom value, ensure the total length does not exceed 64 characters — OpenSSL will error during certificate generation if it does.
+X.509 limits the CN field to **64 characters**. The role enforces this limit in two ways depending on `openvpn_cn_strict_mode`:
 
-| Variable                 | Type   | Choices | Default                                         | Comment                                                                                                                                                                                                     |
-|--------------------------|--------|---------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| openvpn_ca_cn            | string |         | `OpenVPN-CA-{{ inventory_hostname[:53] }}`      | CN for the CA certificate.                                                                                                                                                                                  |
-| openvpn_server_cn        | string |         | `OpenVPN-Server-{{ inventory_hostname[:49] }}`  | CN for the server certificate. A FQDN (e.g. `vpn.example.com`) is also valid. Used in `verify-x509-name` on the client when `openvpn_verify_cn` is enabled.                                                 |
-| openvpn_client_cn_prefix | string |         | `OpenVPN-Client-{{ inventory_hostname[:24] }}-` | Prefix for the client certificate CN (`prefix + client_name`). Set to `""` to use the plain client name as CN. Also used as `name-prefix` in server `verify-x509-name` when `openvpn_verify_cn` is enabled. |
+- **Compatible mode** (default, `false`): CNs that exceed 64 characters are automatically truncated during certificate generation. A warning is printed for each affected CN so the administrator is aware.
+- **Strict mode** (`true`): The role fails immediately at the start of the run if any CN exceeds 64 characters, listing all violations. Use this for new installations where you want explicit control over CN values.
+
+**New installations:** consider setting `openvpn_client_cn_prefix: ""` so the full 64 characters are available for the client name.
+
+**Existing installations:** changing `openvpn_client_cn_prefix` from its default will alter all client CNs, which requires revoking and reissuing every client certificate.
+
+| Variable                 | Type    | Choices     | Default                                         | Comment                                                                                                                                                                                                     |
+|--------------------------|---------|-------------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| openvpn_ca_cn            | string  |             | `OpenVPN-CA-{{ inventory_hostname[:53] }}`      | CN for the CA certificate.                                                                                                                                                                                  |
+| openvpn_server_cn        | string  |             | `OpenVPN-Server-{{ inventory_hostname[:49] }}`  | CN for the server certificate. A FQDN (e.g. `vpn.example.com`) is also valid. Used in `verify-x509-name` on the client when `openvpn_verify_cn` is enabled.                                                 |
+| openvpn_client_cn_prefix | string  |             | `OpenVPN-Client-{{ inventory_hostname[:24] }}-` | Prefix for the client certificate CN (`prefix + client_name`). Set to `""` to use the plain client name as CN. Also used as `name-prefix` in server `verify-x509-name` when `openvpn_verify_cn` is enabled. |
+| openvpn_cn_strict_mode   | boolean | true, false | false                                           | When `true`, the role fails immediately if any CN exceeds 64 characters. When `false` (default), oversized CNs are truncated with a warning, preserving backward compatibility.                             |
 
 ### Operations
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ These options change how OpenVPN itself works. Refer to the respective OpenVPN R
 | openvpn_use_pregenerated_dh_params | boolean | true, false | false       | DH params are generted with the install by default |
 | openvpn_verify_cn                  | boolean | true, false | false       | Check that the CN of the certificate match the FQDN                                                                                                             |
 
+#### Certificate Common Names (CN)
+
+X.509 limits the CN field to **64 characters**. The default values for the variables below truncate `inventory_hostname` so that the built-in prefix and the hostname together stay within this limit. If you supply a custom value, ensure the total length does not exceed 64 characters — OpenSSL will error during certificate generation if it does.
+
+| Variable                 | Type   | Choices | Default                                         | Comment                                                                                                                                                                                                     |
+|--------------------------|--------|---------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| openvpn_ca_cn            | string |         | `OpenVPN-CA-{{ inventory_hostname[:53] }}`      | CN for the CA certificate.                                                                                                                                                                                  |
+| openvpn_server_cn        | string |         | `OpenVPN-Server-{{ inventory_hostname[:49] }}`  | CN for the server certificate. A FQDN (e.g. `vpn.example.com`) is also valid. Used in `verify-x509-name` on the client when `openvpn_verify_cn` is enabled.                                                 |
+| openvpn_client_cn_prefix | string |         | `OpenVPN-Client-{{ inventory_hostname[:24] }}-` | Prefix for the client certificate CN (`prefix + client_name`). Set to `""` to use the plain client name as CN. Also used as `name-prefix` in server `verify-x509-name` when `openvpn_verify_cn` is enabled. |
+
 ### Operations
 
 | Variable                           | Type    | Choices     | Default                                          | Comment                                                                                                                                                                       |

--- a/defaults/main/openvpn.yml
+++ b/defaults/main/openvpn.yml
@@ -37,6 +37,7 @@ openvpn_cipher: AES-256-GCM:AES-128-GCM:AES-256-CBC
 openvpn_ca_cn: "OpenVPN-CA-{{ inventory_hostname[:53] }}"
 openvpn_server_cn: "OpenVPN-Server-{{ inventory_hostname[:49] }}"
 openvpn_client_cn_prefix: "OpenVPN-Client-{{ inventory_hostname[:24] }}-"
+openvpn_cn_strict_mode: false
 openvpn_duplicate_cn: false
 openvpn_rsa_bits: 2048
 openvpn_use_crl: false

--- a/defaults/main/openvpn.yml
+++ b/defaults/main/openvpn.yml
@@ -31,6 +31,12 @@ openvpn_lan_source_ip: "{{ ansible_facts['default_ipv4']['address'] }}"
 # Security
 openvpn_auth_alg: SHA256
 openvpn_cipher: AES-256-GCM:AES-128-GCM:AES-256-CBC
+# X.509 CN is limited to 64 characters. The default values truncate inventory_hostname
+# so that prefix + hostname stays within the limit (e.g. "OpenVPN-CA-" is 11 chars,
+# leaving 53 for the hostname). Adjust truncation when using a custom value.
+openvpn_ca_cn: "OpenVPN-CA-{{ inventory_hostname[:53] }}"
+openvpn_server_cn: "OpenVPN-Server-{{ inventory_hostname[:49] }}"
+openvpn_client_cn_prefix: "OpenVPN-Client-{{ inventory_hostname[:24] }}-"
 openvpn_duplicate_cn: false
 openvpn_rsa_bits: 2048
 openvpn_use_crl: false

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -26,7 +26,7 @@
       - -out
       - "{{ item }}.csr"
       - -subj
-      - /CN={{ openvpn_client_cn_prefix }}{{ item }}/
+      - /CN={{ (openvpn_client_cn_prefix ~ item)[:64] }}/
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ item }}.key"
   with_items:

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -26,7 +26,7 @@
       - -out
       - "{{ item }}.csr"
       - -subj
-      - /CN=OpenVPN-Client-{{ inventory_hostname[:24] }}-{{ item[:24] }}/
+      - /CN={{ openvpn_client_cn_prefix }}{{ item }}/
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ item }}.key"
   with_items:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Validate variables
+  ansible.builtin.import_tasks: validate.yml
+  tags:
+    - always
+    - validate
+
 - name: Include vars for OpenVPN installation
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -43,7 +43,7 @@
       - -out
       - ca-csr.pem
       - -subj
-      - /CN=OpenVPN-CA-{{ inventory_hostname[:53] }}/
+      - /CN={{ openvpn_ca_cn }}/
     chdir: "{{ openvpn_key_dir }}"
     creates: ca-key.pem
   when: openvpn_ca_key is not defined
@@ -74,7 +74,7 @@
       - -out
       - server.csr
       - -subj
-      - /CN=OpenVPN-Server-{{ inventory_hostname[:49] }}/
+      - /CN={{ openvpn_server_cn }}/
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: server.key

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -43,7 +43,7 @@
       - -out
       - ca-csr.pem
       - -subj
-      - /CN={{ openvpn_ca_cn }}/
+      - /CN={{ openvpn_ca_cn[:64] }}/
     chdir: "{{ openvpn_key_dir }}"
     creates: ca-key.pem
   when: openvpn_ca_key is not defined
@@ -74,7 +74,7 @@
       - -out
       - server.csr
       - -subj
-      - /CN={{ openvpn_server_cn }}/
+      - /CN={{ openvpn_server_cn[:64] }}/
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: server.key

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,0 +1,66 @@
+---
+- name: validate | Initialize long client CNs list
+  ansible.builtin.set_fact:
+    __long_client_cns: []
+  tags:
+    - validate
+
+- name: validate | Collect clients with CN exceeding 64 characters
+  ansible.builtin.set_fact:
+    __long_client_cns: "{{ __long_client_cns + [{'name': item, 'cn': __full_client_cn, 'length': __full_client_cn | length}] }}"
+  vars:
+    __full_client_cn: "{{ (openvpn_client_cn_prefix | default('')) ~ item }}"
+  when: __full_client_cn | length > 64
+  loop: "{{ openvpn_clients | default([]) }}"
+  loop_control:
+    label: "{{ item }}"
+  tags:
+    - validate
+
+- name: validate | Strict mode - fail if any CN exceeds 64 characters
+  when: openvpn_cn_strict_mode | bool
+  tags:
+    - validate
+    - strict_mode
+  block:
+    - name: validate | Assert CA CN length (strict mode)
+      ansible.builtin.assert:
+        that: openvpn_ca_cn | length <= 64
+        fail_msg: "FAIL: openvpn_ca_cn exceeds 64 characters ({{ openvpn_ca_cn | length }})"
+
+    - name: validate | Assert server CN length (strict mode)
+      ansible.builtin.assert:
+        that: openvpn_server_cn | length <= 64
+        fail_msg: "FAIL: openvpn_server_cn exceeds 64 characters ({{ openvpn_server_cn | length }})"
+
+    - name: validate | Fail if any client CN too long (strict mode)
+      ansible.builtin.fail:
+        msg: |
+          FAIL: The following client CN(s) exceed 64 characters and are not allowed in strict mode:
+          {% for entry in __long_client_cns -%}
+            - {{ entry.name }} ({{ entry.length }} chars)
+          {% endfor -%}
+      when: __long_client_cns | length > 0
+
+- name: validate | Compatible mode - warn if any CN exceeds 64 characters
+  when: not (openvpn_cn_strict_mode | bool)
+  tags:
+    - validate
+    - compatible_mode
+  block:
+    - name: validate | Warn if CA CN exceeds 64 chars (warning mode)
+      ansible.builtin.debug:
+        msg: "[WARNING] openvpn_ca_cn exceeds 64 characters ({{ openvpn_ca_cn | length }})"
+      when: openvpn_ca_cn | length > 64
+
+    - name: validate | Warn if server CN exceeds 64 chars (warning mode)
+      ansible.builtin.debug:
+        msg: "[WARNING] openvpn_server_cn exceeds 64 characters ({{ openvpn_server_cn | length }})"
+      when: openvpn_server_cn | length > 64
+
+    - name: validate | Warn about long client CNs (warning mode)
+      ansible.builtin.debug:
+        msg: "[WARNING] Client CN too long ({{ item.length }}/64 chars), will be truncated to: {{ item.cn[:64] }}"
+      loop: "{{ __long_client_cns }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -65,5 +65,5 @@ key-direction 1
 </key>
 
 {% if openvpn_verify_cn is truthy %}
-verify-x509-name {{ openvpn_server_cn }} name
+verify-x509-name {{ openvpn_server_cn[:64] }} name
 {% endif %}

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -65,5 +65,5 @@ key-direction 1
 </key>
 
 {% if openvpn_verify_cn is truthy %}
-verify-x509-name OpenVPN-Server-{{ inventory_hostname[:49] }} name
+verify-x509-name {{ openvpn_server_cn }} name
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -96,7 +96,9 @@ syslog openvpn
 verb 3
 
 {% if openvpn_verify_cn is truthy %}
-verify-x509-name OpenVPN-Client-{{ inventory_hostname[:24] }} name-prefix
+{% if openvpn_client_cn_prefix %}
+verify-x509-name {{ openvpn_client_cn_prefix }} name-prefix
+{% endif %}
 remote-cert-tls client
 {% endif %}
 


### PR DESCRIPTION
## Add configurable certificate CN variables

### Why

Certificate Common Names for CA, server, and client certs were hardcoded as `OpenVPN-CA-<inventory_hostname>`, `OpenVPN-Server-<inventory_hostname>`, and `OpenVPN-Client-<inventory_hostname>-<client>`. This worked, but had two practical problems:

**Client CNs were hard to read.** When you run `show clients` in the OpenVPN management interface or look at the status file, you see entries like `OpenVPN-Client-myvpnserver-alice` instead of just `alice`. With many clients this makes scanning the list painful.

**Server CN couldn't be a clean FQDN.** Best practice for TLS certificates is to use a proper domain name as the CN (e.g. `vpn.example.com`). There was no way to do that without patching the role.

### What changed

Three new variables:

- **`openvpn_ca_cn`** — CN for the CA certificate.
- **`openvpn_server_cn`** — CN for the server certificate. Can be set to a plain FQDN like `{{ openvpn_server_hostname }}` or any domain name.
- **`openvpn_client_cn_prefix`** — prefix prepended to the client name to form the client certificate CN. Set it to `""` and the CN becomes just the client name (e.g. `firstname.lastname`). Set it to a custom string for any other format.

`openvpn_client_cn_prefix` also drives the `verify-x509-name … name-prefix` directive in `server.conf` when `openvpn_verify_cn` is enabled. Setting it to `""` disables prefix-based verification while keeping `remote-cert-tls client` active.

All defaults reproduce the previous behaviour exactly, so existing deployments are unaffected.