### PR TITLE
Enable dbus.socket in dnf-based test images

### DIFF
--- a/tests/almalinux.Dockerfile
+++ b/tests/almalinux.Dockerfile
@@ -42,6 +42,12 @@ RUN dnf -y install \
     python3-dnf \
     && dnf clean all
 
+# The systemd cleanup above deletes the dbus.socket enablement symlink from
+# /etc/systemd/system/sockets.target.wants. EL10's firewalld.service no longer
+# has Requires=dbus.service to pull dbus up anyway, so without this the
+# ansible.posix.firewalld module can't reach firewalld over D-Bus.
+RUN systemctl enable dbus.socket
+
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts

--- a/tests/centos.Dockerfile
+++ b/tests/centos.Dockerfile
@@ -42,6 +42,12 @@ RUN dnf -y install \
     python3-dnf \
     && dnf clean all
 
+# The systemd cleanup above deletes the dbus.socket enablement symlink from
+# /etc/systemd/system/sockets.target.wants. EL10's firewalld.service no longer
+# has Requires=dbus.service to pull dbus up anyway, so without this the
+# ansible.posix.firewalld module can't reach firewalld over D-Bus.
+RUN systemctl enable dbus.socket
+
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts

--- a/tests/fedora.Dockerfile
+++ b/tests/fedora.Dockerfile
@@ -40,6 +40,12 @@ RUN dnf -y install \
     python3-dnf \
     && dnf clean all
 
+# The systemd cleanup above deletes the dbus.socket enablement symlink from
+# /etc/systemd/system/sockets.target.wants. EL10's firewalld.service no longer
+# has Requires=dbus.service to pull dbus up anyway, so without this the
+# ansible.posix.firewalld module can't reach firewalld over D-Bus.
+RUN systemctl enable dbus.socket
+
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts

--- a/tests/rockylinux.Dockerfile
+++ b/tests/rockylinux.Dockerfile
@@ -43,6 +43,12 @@ RUN dnf -y install \
     python3-dnf \
     && dnf clean all
 
+# The systemd cleanup above deletes the dbus.socket enablement symlink from
+# /etc/systemd/system/sockets.target.wants. EL10's firewalld.service no longer
+# has Requires=dbus.service to pull dbus up anyway, so without this the
+# ansible.posix.firewalld module can't reach firewalld over D-Bus.
+RUN systemctl enable dbus.socket
+
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts


### PR DESCRIPTION
The systemd cleanup step removes the dbus.socket enablement symlink from /etc/systemd/system/sockets.target.wants. On EL9 this was masked because firewalld.service had Requires=dbus.service, which pulled dbus up anyway; firewalld 2.4 on EL10 dropped that dependency, so dbus never starts and the ansible.posix.firewalld module fails with "firewall is not currently running" even though firewalld itself is active.

Re-enable dbus.socket at build time so the EL10 CI jobs (centos-stream10, almalinux-10, rockylinux-10) can talk to firewalld over D-Bus.