### PR TITLE
Update CI test matrix for EOL distro versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: check-syntax
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@v26.6.0
         with:
           requirements_file: requirements.yml
 
@@ -42,7 +42,7 @@ jobs:
       options: "--cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/net/tun"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
       - name: Update ansible
         run: dnf install -y python39 && pip3.9 install -U ansible
       - name: Install required dependencies from Ansible Galaxy
@@ -76,7 +76,6 @@ jobs:
       matrix:
         version:
           - "ubuntu:22.04"
-          - "debian:12"
 
     container:
       image: diodonfrost/ansible-${{ matrix.version }}
@@ -88,7 +87,7 @@ jobs:
       options: "--cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/net/tun"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
       - name: Upgrade ansible
         run: apt update && apt-get install --only-upgrade ansible -y
       - name: Install required dependencies from Ansible Galaxy
@@ -117,8 +116,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "fedora-42"
           - "fedora-43"
+          - "fedora-44"
           - "almalinux-9"
           - "almalinux-10"
           - "rockylinux-9"
@@ -127,12 +126,12 @@ jobs:
           - "centos-stream10"
           - "debian-13"
           - "ubuntu-24.04"
-          - "ubuntu-25.10"
+          - "ubuntu-26.04"
           # - "ubi9-init"
           # - "ubi10-init"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Create container

--- a/.github/workflows/publish-almalinux.yml
+++ b/.github/workflows/publish-almalinux.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/publish-centos.yml
+++ b/.github/workflows/publish-centos.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/publish-debian.yml
+++ b/.github/workflows/publish-debian.yml
@@ -19,11 +19,11 @@ jobs:
 
     strategy:
       matrix:
-        debian_version: ["12", "13"]
+        debian_version: ["13"]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/publish-fedora.yml
+++ b/.github/workflows/publish-fedora.yml
@@ -19,11 +19,11 @@ jobs:
 
     strategy:
       matrix:
-        fedora_version: ["42", "43"]
+        fedora_version: ["43", "44"]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/publish-rockylinux.yml
+++ b/.github/workflows/publish-rockylinux.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/publish-ubi.yml
+++ b/.github/workflows/publish-ubi.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/publish-ubuntu.yml
+++ b/.github/workflows/publish-ubuntu.yml
@@ -19,11 +19,11 @@ jobs:
 
     strategy:
       matrix:
-        ubuntu_version: ["22.04", "24.04", "25.10"]
+        ubuntu_version: ["22.04", "24.04", "26.04"]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Log in to the Container registry
         uses: redhat-actions/podman-login@v1

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This role installs OpenVPN, configures it as a server, sets up networking and fi
 
 OSes in CI build:
 
-- Fedora 42+
+- Fedora 43+
 - CentOS Stream 9 & 10
 - AlmaLinux/Rocky 9 & 10
-- Debian 12 & 13
-- Ubuntu 22.04/24.04/25.10
+- Debian 13
+- Ubuntu 22.04/24.04/26.04
 
 Note: I am providing code in the repository to you under an open source license. Because this is my personal repository, the license you receive to my code is from me and not my employer.
 

--- a/tests/ubuntu.Dockerfile
+++ b/tests/ubuntu.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     rsync \
     sudo \
-    fuse snapd snap-confine squashfuse \
+    fuse snapd squashfuse \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Per endoflife.date as of 2026-07-06:
- Fedora 42 (EOL 2026-05-27) -> Fedora 44
- Ubuntu 25.10 (EOL 2026-07-01) -> Ubuntu 26.04 LTS
- Debian 12 (EOL 2026-07-11) removed; Debian 13 already covered by the systemd job

Also bump the various `actions/` versions in use & remove `snap-confine` from Ubuntu dockerfile for 26.04 to build successfully