### PR TITLE
Better Firewall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ These options change how OpenVPN itself works. Refer to the respective OpenVPN R
 | openvpn_server_netmask      | string       |                   | 255.255.255.0              | Netmask of the private network     |
 | openvpn_server_netmask_cidr      | string       |                   | Determined at runtime from `openvpn_server_network` and `openvpn_server_netmask` | CIDR suffix to use in firewall rules |
 | openvpn_server_network      | string       |                   | 10.9.0.0                   | Private network used by OpenVPN service                                                                                                              |
+| openvpn_snat_source_ipv4    | string       |                   | `ansible_facts['default_ipv4']['address']` | Source address used for IPv4 SNAT rules (iptables/ufw, SNAT mode only). Override this if the host's default IPv4 route doesn't reflect the address you want to NAT to, or set explicitly to avoid depending on `ansible_facts['default_ipv4']` at all. |
+| openvpn_snat_source_ipv6    | string       |                   | `ansible_facts['default_ipv6']['address']` | Source address used for IPv6 SNAT rules (iptables/ufw, SNAT mode only). Same override use case as `openvpn_snat_source_ipv4`, for IPv6. |
 | openvpn_tun_mtu             | int          |                   | `unset`                    | Set `tun-mtu` value. Empty for default.                                                                                                              |
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Change these options if you need to force a particular firewall or change how th
 | openvpn_firewall                 | string  | auto, firewalld, ufw, iptables | auto     | The firewall software to configure network rules. "auto" will attempt to detect it by inspecting the system |
 | openvpn_masquerade_not_snat      | boolean | true, false                    | false    | Set to true if you want to set up MASQUERADE instead of the default SNAT in iptables.                       |
 | openvpn_no_nat           | boolean | true, false                    | false    | Disable NAT configuration                                                                                   |
+| openvpn_firewalld_zone           | string  | auto, or a zone name          | auto     | Zone to add firewalld rules to. "auto" detects firewalld's configured default zone; set explicitly to skip detection. |
 
 ## OpenVPN Config Options
 

--- a/defaults/main/openvpn.yml
+++ b/defaults/main/openvpn.yml
@@ -26,7 +26,8 @@ openvpn_server_netmask_cidr: "{{ (openvpn_server_network + '/' + openvpn_server_
 openvpn_server_ipv6_network: "fdbf:dd0d:1a49:2091::/64"
 openvpn_set_dns: true
 openvpn_tun_mtu:
-openvpn_lan_source_ip: "{{ ansible_facts['default_ipv4']['address'] }}"
+openvpn_snat_source_ipv4: "{{ ansible_facts['default_ipv4']['address'] }}"
+openvpn_snat_source_ipv6: "{{ ansible_facts['default_ipv6']['address'] }}"
 
 # Security
 openvpn_auth_alg: SHA256

--- a/defaults/main/role.yml
+++ b/defaults/main/role.yml
@@ -24,6 +24,9 @@ openvpn_manage_firewall_rules: true
 openvpn_firewall: auto
 openvpn_masquerade_not_snat: false
 openvpn_no_nat: false
+# Zone to add firewalld rules to. Defaults to autodetecting firewalld's configured default zone;
+# set explicitly (e.g. "public") to skip autodetection.
+openvpn_firewalld_zone: auto
 
 # Misc
 openvpn_ci_build: false

--- a/tasks/firewall/firewall.yml
+++ b/tasks/firewall/firewall.yml
@@ -16,33 +16,21 @@
     - "'ufw' not in ansible_facts['packages']"
     - "'iptables' not in ansible_facts['packages']"
 
+- name: firewall | firewall | Determine firewall backend
+  ansible.builtin.set_fact:
+    __openvpn_firewall_backend: >-
+      {{ openvpn_firewall if openvpn_firewall != 'auto' else
+         ('firewalld' if 'firewalld' in ansible_facts['packages'] else
+          ('ufw' if 'ufw' in ansible_facts['packages'] else 'iptables')) }}
+
 - name: firewall | firewall | Add port rules (iptables)
   ansible.builtin.include_tasks: iptables.yml
-  when: >-
-    (openvpn_firewall == 'iptables')
-    or
-    (openvpn_firewall == 'auto'
-      and 'firewalld' not in ansible_facts.packages
-      and 'ufw' not in ansible_facts.packages
-      and 'iptables' in ansible_facts.packages
-    )
+  when: __openvpn_firewall_backend == 'iptables'
 
 - name: firewall | firewall | Add port rules (firewalld)
   ansible.builtin.include_tasks: firewalld.yml
-  when: >-
-    (openvpn_firewall == 'firewalld')
-    or
-    (openvpn_firewall == 'auto'
-      and 'firewalld' in ansible_facts.packages
-      and 'ufw' not in ansible_facts.packages
-    )
+  when: __openvpn_firewall_backend == 'firewalld'
 
 - name: firewall | firewall | Add port rules (ufw)
   ansible.builtin.include_tasks: ufw.yml
-  when: >-
-    (openvpn_firewall == 'ufw')
-    or
-    (openvpn_firewall == 'auto'
-      and 'firewalld' not in ansible_facts.packages
-      and 'ufw' in ansible_facts.packages
-    )
+  when: __openvpn_firewall_backend == 'ufw'

--- a/tasks/firewall/firewall.yml
+++ b/tasks/firewall/firewall.yml
@@ -23,6 +23,40 @@
          ('firewalld' if 'firewalld' in ansible_facts['packages'] else
           ('ufw' if 'ufw' in ansible_facts['packages'] else 'iptables')) }}
 
+# Only iptables/ufw embed a source address directly into their SNAT rules - firewalld's
+# masquerade doesn't need one, and MASQUERADE mode picks the address at packet-send time.
+- name: firewall | firewall | Fail if IPv4 SNAT is needed but no default IPv4 route exists
+  ansible.builtin.fail:
+    msg: >-
+      openvpn_no_nat and openvpn_masquerade_not_snat are both false (SNAT mode) but this host
+      has no default IPv4 route (ansible_facts['default_ipv4'] is empty), so
+      openvpn_snat_source_ipv4 can't be resolved. Either set openvpn_snat_source_ipv4 explicitly,
+      set openvpn_masquerade_not_snat: true to use MASQUERADE instead, set openvpn_no_nat: true if
+      this host doesn't need NAT at all, or set openvpn_server_network: "" to disable the IPv4
+      tunnel entirely.
+  when:
+    - __openvpn_firewall_backend in ['iptables', 'ufw']
+    - openvpn_no_nat is falsy
+    - openvpn_masquerade_not_snat is falsy
+    - openvpn_server_network is defined and openvpn_server_network | length > 0
+    - openvpn_snat_source_ipv4 is not defined
+
+- name: firewall | firewall | Fail if IPv6 SNAT is needed but no default IPv6 route exists
+  ansible.builtin.fail:
+    msg: >-
+      openvpn_server_ipv6_network is set to "{{ openvpn_server_ipv6_network }}" but this host
+      has no default IPv6 route (ansible_facts['default_ipv6'] is empty), so
+      openvpn_snat_source_ipv6 can't be resolved. Either set openvpn_snat_source_ipv6 explicitly,
+      set openvpn_server_ipv6_network: "" to disable IPv6 support, or set
+      openvpn_masquerade_not_snat: true to use MASQUERADE instead, which doesn't require a known
+      source address.
+  when:
+    - __openvpn_firewall_backend in ['iptables', 'ufw']
+    - openvpn_no_nat is falsy
+    - openvpn_masquerade_not_snat is falsy
+    - openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
+    - openvpn_snat_source_ipv6 is not defined
+
 - name: firewall | firewall | Add port rules (iptables)
   ansible.builtin.include_tasks: iptables.yml
   when: __openvpn_firewall_backend == 'iptables'

--- a/tasks/firewall/firewall.yml
+++ b/tasks/firewall/firewall.yml
@@ -4,17 +4,17 @@
     msg: "Both FirewallD and UFW are detected, firewall situation is unknown"
   when:
     - openvpn_firewall == 'auto'
-    - "'firewalld' in ansible_facts.packages"
-    - "'ufw' in ansible_facts.packages"
+    - "'firewalld' in ansible_facts['packages']"
+    - "'ufw' in ansible_facts['packages']"
 
 - name: firewall | firewall | Fail on no firewall detected
   ansible.builtin.fail:
     msg: "No firewall detected, install one before proceeding (firewalld||ufw||iptables)"
   when:
     - openvpn_firewall == 'auto'
-    - "'firewalld' not in ansible_facts.packages"
-    - "'ufw' not in ansible_facts.packages"
-    - "'iptables' not in ansible_facts.packages"
+    - "'firewalld' not in ansible_facts['packages']"
+    - "'ufw' not in ansible_facts['packages']"
+    - "'iptables' not in ansible_facts['packages']"
 
 - name: firewall | firewall | Add port rules (iptables)
   ansible.builtin.include_tasks: iptables.yml

--- a/tasks/firewall/firewalld.yml
+++ b/tasks/firewall/firewalld.yml
@@ -6,20 +6,27 @@
     masked: false
     state: started
 
-# Default interface is the one that routes the traffic
-# Assume that's what we want for a server
-# https://medium.com/opsops/ansible-default-ipv4-is-not-what-you-think-edb8ab154b10
-- name: firewall | firewalld | Get zone of default interface
-  ansible.builtin.command: firewall-cmd --get-zone-of-interface={{ ansible_facts['default_ipv4']['interface'] }}
-  register: __firewalld_default_zone
+# Ask firewalld for its configured default zone rather than looking up the zone of
+# ansible_facts['default_ipv4']['interface'], so this doesn't depend on the host having an
+# IPv4 (or IPv6) default route at all. Set openvpn_firewalld_zone explicitly to skip
+# autodetection altogether.
+- name: firewall | firewalld | Get default zone
+  ansible.builtin.command: firewall-cmd --get-default-zone
+  register: __firewalld_autodetected_zone
   check_mode: false
   changed_when: false # Read only, never report as changed
   failed_when: false
+  when: openvpn_firewalld_zone == 'auto'
+
+- name: firewall | firewalld | Set firewalld zone fact
+  ansible.builtin.set_fact:
+    __firewalld_default_zone: >-
+      {{ openvpn_firewalld_zone if openvpn_firewalld_zone != 'auto' else __firewalld_autodetected_zone.stdout }}
 
 - name: firewall | firewalld | Enable OpenVPN Port (firewalld)
   ansible.posix.firewalld:
     port: "{{ openvpn_port }}/{{ openvpn_proto }}"
-    zone: "{{ __firewalld_default_zone.stdout }}"
+    zone: "{{ __firewalld_default_zone }}"
     permanent: true
     immediate: true
     state: enabled
@@ -37,7 +44,7 @@
 - name: firewall | firewalld | Enable masquerading on default interface's zone
   ansible.posix.firewalld:
     masquerade: true
-    zone: "{{ __firewalld_default_zone.stdout }}"
+    zone: "{{ __firewalld_default_zone }}"
     permanent: true
     state: enabled
     immediate: true
@@ -47,7 +54,7 @@
 - name: firewall | firewalld | Enable masquerading on ipv6
   ansible.posix.firewalld:
     rich_rule: rule family=ipv6 masquerade
-    zone: "{{ __firewalld_default_zone.stdout }}"
+    zone: "{{ __firewalld_default_zone }}"
     permanent: true
     state: enabled
     immediate: true

--- a/tasks/firewall/iptables.yml
+++ b/tasks/firewall/iptables.yml
@@ -61,7 +61,7 @@
         chain: POSTROUTING
         source: "{{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
         destination: "! {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }}"
-        to_source: "{{ ansible_facts['default_ipv4']['address'] }}"
+        to_source: "{{ openvpn_snat_source_ipv4 }}"
         jump: SNAT
         action: insert
         comment: "Perform NAT readdressing"
@@ -71,7 +71,7 @@
         chain: POSTROUTING
         source: "{{ openvpn_server_ipv6_network }}"
         destination: "! {{ openvpn_server_ipv6_network }}"
-        to_source: "{{ ansible_facts['default_ipv6']['address'] }}"
+        to_source: "{{ openvpn_snat_source_ipv6 }}"
         jump: SNAT
         action: insert
         comment: "Perform NAT IPv6 readdressing"

--- a/tasks/firewall/ufw.yml
+++ b/tasks/firewall/ufw.yml
@@ -44,7 +44,7 @@
           # OpenVPN config
           *nat
           :POSTROUTING ACCEPT [0:0]
-          -A POSTROUTING -s {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }} ! -d {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }} -j SNAT --to-source {{ openvpn_lan_source_ip }}
+          -A POSTROUTING -s {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }} ! -d {{ openvpn_server_network }}/{{ openvpn_server_netmask_cidr }} -j SNAT --to-source {{ openvpn_snat_source_ipv4 }}
           COMMIT
 
     - name: firewall | ufw | Setup IPv6 SNAT rules
@@ -56,7 +56,7 @@
           # OpenVPN config
           *nat
           :POSTROUTING ACCEPT [0:0]
-          -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }} -j SNAT --to-source {{ ansible_facts['default_ipv6']['address'] }}
+          -A POSTROUTING -s {{ openvpn_server_ipv6_network }} ! -d {{ openvpn_server_ipv6_network }} -j SNAT --to-source {{ openvpn_snat_source_ipv6 }}
           COMMIT
       when: openvpn_server_ipv6_network is defined and openvpn_server_ipv6_network | length > 0
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
     update_cache: true
   when:
     - ansible_facts["pkg_mgr"] == "apt"
-    - openvpn_package_name not in ansible_facts.packages
+    - openvpn_package_name not in ansible_facts['packages']
 
 - name: install | Install openvpn
   ansible.builtin.package:


### PR DESCRIPTION
* Simplify firewall detection
* Use ['packages'] instead of '.packages' when checking installed packages
* Add SNAT IP override parameters (Fixes #273)
* Use default zone in firewalld vs specifically checking the zone of the interface with the default v4 route